### PR TITLE
applyAlignment should be included in xf

### DIFF
--- a/lib/axlsx/stylesheet/styles.rb
+++ b/lib/axlsx/stylesheet/styles.rb
@@ -230,6 +230,7 @@ module Axlsx
       
       if options[:alignment]
         xf.alignment = CellAlignment.new(options[:alignment])
+        xf.applyAlignment = true
       end
       
       if applyProtection

--- a/test/stylesheet/tc_styles.rb
+++ b/test/stylesheet/tc_styles.rb
@@ -49,8 +49,8 @@ class TestStyles < Test::Unit::TestCase
     
     assert_equal(xf.applyProtection, 1, "protection applied")
     assert_equal(xf.applyBorder, true, "border applied")
-    assert_equal(xf.applyNumberFormat, true, "border applied")
-
+    assert_equal(xf.applyNumberFormat, true, "number format applied")
+    assert_equal(xf.applyAlignment, true, "alignment applied")
   end
 
 end


### PR DESCRIPTION
It seems some spreadsheet software including OpenOffice refuse to apply alignment in style if appleAlignment is not set to true.
