### PR TITLE
Force result of Fixnum division to integer before using

### DIFF
--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -71,7 +71,7 @@ module Axlsx
     chars = []
     while index >= 26 do
       chars << ((index % 26) + 65).chr
-      index = index / 26 - 1
+      index = (index / 26).to_i - 1
     end
     chars << (index + 65).chr
     chars.reverse.join


### PR DESCRIPTION
The [mathn](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/mathn/rdoc/index.html) library overrides Fixnum division to return a rational, so
`1/2 => (1/2)` instead of `1/2 => 0`. Axlsx calls chr on the result of
Fixnum division, which is incompatible. Fix it by forcing to integer.
