### PR TITLE
fix Table#header_cells method

### DIFF
--- a/lib/axlsx/workbook/worksheet/table.rb
+++ b/lib/axlsx/workbook/worksheet/table.rb
@@ -89,7 +89,7 @@ module Axlsx
 
     # get the header cells (hackish)
     def header_cells
-      header = @ref.gsub(/^(\w+)(\d+)\:(\w+)\d+$/, '\1\2:\3\2')
+      header = @ref.gsub(/^(\w+?)(\d+)\:(\w+?)\d+$/, '\1\2:\3\2')
       @sheet[header]
     end
   end


### PR DESCRIPTION
Changed to a non-greedy \w so table's are generated properly

Without fix:

``` ruby
"A1:Q19".gsub(/^(\w+)(\d+)\:(\w+)\d+$/, '\1\2:\3\2')
=> "A1:Q11"
```

With fix:

``` ruby
"A1:Q19".gsub(/^(\w+?)(\d+)\:(\w+?)\d+$/, '\1\2:\3\2')
=> "A1:Q1"
```
