### PR TITLE
Google Docs interoperability

### DIFF
--- a/lib/axlsx/doc_props/core.rb
+++ b/lib/axlsx/doc_props/core.rb
@@ -22,7 +22,7 @@ module Axlsx
       str << 'xmlns:dcmitype="' << CORE_NS_DCMIT << '" xmlns:dcterms="' << CORE_NS_DCT << '" '
       str << 'xmlns:xsi="' << CORE_NS_XSI << '">'
       str << '<dc:creator>' << self.creator << '</dc:creator>'
-      str << '<dcterms:created xsi:type="dcterms:W3CDTF">' << Time.now.strftime('%Y-%m-%dT%H:%M:%S') << '</dcterms:created>'
+      str << '<dcterms:created xsi:type="dcterms:W3CDTF">' << Time.now.strftime('%Y-%m-%dT%H:%M:%S') << 'Z</dcterms:created>'
       str << '<cp:revision>0</cp:revision>'
       str << '</cp:coreProperties>'
     end


### PR DESCRIPTION
Google is especially sensitive to the format of the created stamp
in the core.xml document. It must end in Z and will not accept
another timezone offset or no timezone offset.

This seems to work for all my documents.

See #80
