### PR TITLE
Updated README to point to axlsx_rails, a new plugin for xlsx templates using xlsx or acts_as_xlsx.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Axlsx: Office Open XML Spreadsheet Generation
 **Release Date**: July 14th 2012
 
 If you are working in rails, or with active record see:
-http://github.com/randym/acts_as_xlsx or http://github.com/straydogstudio/axlsx_rails
+* http://github.com/randym/acts_as_xlsx
+* http://github.com/straydogstudio/axlsx_rails
 
 There are guides for using axlsx and acts_as_xlsx here:
 [http://axlsx.blogspot.com](http://axlsx.blogspot.com)


### PR DESCRIPTION
Acts_as_xlsx is nice, but I've needed spreadsheets that don't fit a model, and I hate having lots of view code in my controller. So, I created axlsx_rails to provide a .xlsx renderer and template handler. The xlsx_package object is provided, so either plain axlsx or acts_as_xlsx works. The gem includes tests.

I've tested it on Rails 3.2. I think it will work on Rails 3.1, but I've not checked. 

This pull request only includes a change to the README file so axlsx_rails is mentioned.

Noel
