### PR TITLE
Fix for issue 127

### DIFF
--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -497,7 +497,14 @@ module Axlsx
         item.to_xml_string(str) if item
       end
       str << '</worksheet>'
-      str.gsub(/[[:cntrl:]]/,'')
+
+      if RUBY_VERSION == "1.8.7"
+        nasty_control_char_matcher = Regexp.new("[\x01\x02\x03\x04\x05\x06\x07\x08\x1F\v\xE2]")
+      else
+        nasty_control_char_matcher = Regexp.new("[\x01\x02\x03\x04\x05\x06\x07\x08\x1F\v\u2028]")
+      end
+
+      str.gsub(nasty_control_char_matcher,'')
     end
 
     # The worksheet relationships. This is managed automatically by the worksheet

--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -324,6 +324,13 @@ class TestWorksheet < Test::Unit::TestCase
     assert_equal(0, @ws.rows.last.cells.last.value.index("\v"))
     assert_equal(nil,@ws.to_xml_string.index("\v"))
   end
+
+  def test_to_xml_string_with_newlines
+    cell_with_newline = "foo\n\r\nbar"
+    @ws.add_row [cell_with_newline]
+    assert_equal("foo\n\r\nbar", @ws.rows.last.cells.last.value)
+    assert_not_nil(@ws.to_xml_string.index("foo\n\r\nbar"))
+  end
   # Make sure the XML for all optional elements (like pageMargins, autoFilter, ...)
   # is generated in correct order.
   def test_valid_with_optional_elements


### PR DESCRIPTION
XML output was stripping newlines along with all other control characters. This fix strips only "nasty" control characters, and preserves newlines. 

Included is a test that exposes the issue. 
