### PR TITLE
Escape URLs used as target for hyperlinks.

### DIFF
--- a/lib/axlsx/rels/relationship.rb
+++ b/lib/axlsx/rels/relationship.rb
@@ -55,7 +55,7 @@ module Axlsx
       h = self.instance_values
       h[:Id] = 'rId' << rId.to_s
       str << '<Relationship '
-      str << h.map { |key, value| '' << key.to_s << '="' << value.to_s << '"'}.join(' ')
+      str << h.map { |key, value| '' << key.to_s << '="' << Axlsx::coder.encode(value.to_s) << '"'}.join(' ')
       str << '/>'
     end
 

--- a/lib/axlsx/workbook/worksheet/worksheet_hyperlink.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet_hyperlink.rb
@@ -73,7 +73,7 @@ module Axlsx
     # r:id should only be specified for external targets.
     # @return [Hash]
     def location_or_id
-      @target == :external ?  { :"r:id" => id } : { :location => location }
+      @target == :external ?  { :"r:id" => id } : { :location => Axlsx::coder.encode(location) }
     end
   end
 end

--- a/test/rels/tc_relationship.rb
+++ b/test/rels/tc_relationship.rb
@@ -18,4 +18,9 @@ class TestRelationships < Test::Unit::TestCase
     assert_nothing_raised { Axlsx::Relationship.new( Axlsx::WORKSHEET_R, 'target', :target_mode => :External) }
   end
 
+  def test_ampersand_escaping_in_target
+    r = Axlsx::Relationship.new(Axlsx::HYPERLINK_R, "http://example.com?foo=1&bar=2", :target_mod => :External)
+    doc = Nokogiri::XML(r.to_xml_string(1))
+    assert_equal(doc.xpath("//Relationship[@Target='http://example.com?foo=1&bar=2']").size, 1)
+  end
 end

--- a/test/workbook/worksheet/tc_worksheet_hyperlink.rb
+++ b/test/workbook/worksheet/tc_worksheet_hyperlink.rb
@@ -5,7 +5,7 @@ class TestWorksheetHyperlink < Test::Unit::TestCase
     p = Axlsx::Package.new
     wb = p.workbook
     @ws = wb.add_worksheet
-    @options = { :location => 'https://github.com/randym/axlsx', :tooltip => 'axlsx', :ref => 'A1', :display => 'AXSLX', :target => :internal }
+    @options = { :location => 'https://github.com/randym/axlsx?foo=1&bar=2', :tooltip => 'axlsx', :ref => 'A1', :display => 'AXSLX', :target => :internal }
     @a = @ws.add_hyperlink @options
   end
 


### PR DESCRIPTION
Up to now, when using an URL containing a & character, the generated XML was invalid.
