### PR TITLE
Different left/right border style

### DIFF
--- a/examples/styles.rb
+++ b/examples/styles.rb
@@ -49,7 +49,7 @@ wb.styles do |style|
   custom_format = wb.styles.add_style :sz => 20, :format_code => 'yyyy-mm-dd'
 
   # A style that overrides top and left border style
-  one_border = wb.styles.add_style :border => { :style => :thin, :color =>"FAAC58", :edges => [:right, :top, :left] }, :border_top => { :style => :thick, :color => "01DF74" }, :border_left => { :color => "0101DF" }
+  override_border = wb.styles.add_style :border => { :style => :thin, :color =>"FAAC58", :edges => [:right, :top, :left] }, :border_top => { :style => :thick, :color => "01DF74" }, :border_left => { :color => "0101DF" }
 
 
   wb.add_worksheet do |sheet|
@@ -58,7 +58,7 @@ wb.styles do |style|
     sheet.add_row [123, "123", Time.now], style: [nil, large_font, predefined_format]
     sheet.add_row [123, "123", Date.new(2012, 9, 14)], style: [large_font, nil, custom_format]
     sheet.add_row [123, "123", Date.new(2000, 9, 12)] # This uses the axlsx default format_code (14)
-    sheet.add_row [123, "123", Time.now], style: [large_font, one_border, predefined_format]
+    sheet.add_row [123, "123", Time.now], style: [large_font, override_border, predefined_format]
   end
 
 end

--- a/lib/axlsx/stylesheet/styles.rb
+++ b/lib/axlsx/stylesheet/styles.rb
@@ -321,10 +321,9 @@ module Axlsx
         raise ArgumentError, (ERR_INVALID_BORDER_OPTIONS % b_opts) unless b_opts.keys.include?(:style) && b_opts.keys.include?(:color)
         border = Border.new b_opts
         (b_opts[:edges] || [:left, :right, :top, :bottom]).each do |edge|
-		  sb_opts = options["border_#{edge}".to_sym]
-		  style = (!sb_opts.nil? && sb_opts.keys.include?(:style)) ? sb_opts[:style] : b_opts[:style]
-		  color = (!sb_opts.nil? && sb_opts.keys.include?(:color)) ? sb_opts[:color] : b_opts[:color]
-		  b_options = { :name => edge, :style => style, :color => Color.new(:rgb => color) }
+          edge_options = options["border_#{edge}".to_sym] || {}
+          border_edge = b_opts.merge(edge_options)
+          b_options = { :name => edge, :style => border_edge[:style], :color => Color.new(:rgb => border_edge[:color]) }
           border.prs << BorderPr.new(b_options)
         end
         options[:type] == :dxf ? border : borders << border


### PR DESCRIPTION
Here you go, take a look at my pull request.
I updated source and example source, so it could be easily  tested.

If specific edge isn't specified, then :border_[name] don't override it. Style and/or color can be overridden individually.
