### PR TITLE
Fixes related to validating worksheet name uniqueness

### DIFF
--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -637,14 +637,14 @@ module Axlsx
         end
         sheet_view.show_outline_symbols = true
       end
-
     end
+
     def validate_sheet_name(name)
       DataTypeValidator.validate "Worksheet.name", String, name
       raise ArgumentError, (ERR_SHEET_NAME_TOO_LONG % name) if name.size > 31
       raise ArgumentError, (ERR_SHEET_NAME_CHARACTER_FORBIDDEN % name) if '[]*/\?:'.chars.any? { |char| name.include? char }
       name = Axlsx::coder.encode(name)
-      sheet_names = @workbook.worksheets.map { |s| s.name }
+      sheet_names = @workbook.worksheets.reject { |s| s == self }.map { |s| s.name }
       raise ArgumentError, (ERR_DUPLICATE_SHEET_NAME % name) if sheet_names.include?(name)
     end
 

--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -405,6 +405,11 @@ class TestWorksheet < Test::Unit::TestCase
     assert_raise(ArgumentError, "worksheet name must be unique") { n = @ws.name; @ws.workbook.add_worksheet(:name=> n) }
   end
 
+  def test_name_unique_only_checks_other_worksheet_names
+    assert_nothing_raised { @ws.name = @ws.name }
+    assert_nothing_raised { Axlsx::Package.new.workbook.add_worksheet :name => 'Sheet1' }
+  end
+
   def test_name_size
     assert_raise(ArgumentError, "name too long!") { @ws.name = Array.new(32, "A").join() }
     assert_nothing_raised { @ws.name = Array.new(31, "A").join() }


### PR DESCRIPTION
0523e90 (Edward Anderson, 5 minutes ago)
   Worksheet name uniqueness doesn't apply to itself

   This constraint would prevent you from creating a new worksheet with the
   name that it would have gotten by default.

cac5b8a (Edward Anderson, 33 minutes ago)
   Don't add worksheets to the workbook when initialize fails

   Creating a worksheet with an invalid name would still add it to the
   workbook, despite raising an exception.
