### PR TITLE
Add support for preserving leading and trailing spaces in cell values

### DIFF
--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -37,6 +37,7 @@ module Axlsx
       @page_setup = PageSetup.new options[:page_setup]  if options[:page_setup]
       @print_options = PrintOptions.new options[:print_options] if options[:print_options]
       @header_footer = HeaderFooter.new options[:header_footer] if options[:header_footer]
+      @preserve_spaces = options.fetch(:preserve_spaces, true)
     end
 
     # The name of the worksheet
@@ -326,6 +327,10 @@ module Axlsx
       DataTypeValidator.validate "Worksheet.auto_filter", String, v
       auto_filter.range = v
     end
+
+    # Accessor for controlling whether leading and trailing spaces in cells are
+    # preserved or ignored. The default is to preserve spaces.
+    attr_accessor :preserve_spaces
 
     # The part name of this worksheet
     # @return [String]
@@ -699,7 +704,9 @@ module Axlsx
     # Helper method for parsingout the root node for worksheet
     # @return [String]
     def worksheet_node
-      "<worksheet xmlns=\"%s\" xmlns:r=\"%s\">" % [XML_NS, XML_NS_R]
+      (@preserve_spaces ?
+        "<worksheet xmlns=\"%s\" xmlns:r=\"%s\" xml:space=\"preserve\">" :
+        "<worksheet xmlns=\"%s\" xmlns:r=\"%s\">") % [XML_NS, XML_NS_R]
     end
 
     def sheet_data

--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -352,6 +352,15 @@ class TestWorksheet < Test::Unit::TestCase
     assert(schema.validate(doc).map{ |e| puts e.message; e }.empty?, "error free validation")
   end
 
+  def test_to_xml_string_with_preserve_spaces
+    # Check that xml:space="preserve" has been added when preserve_spaces is set
+    ws_xml = Nokogiri::XML(@ws.to_xml_string)
+    assert(ws_xml.xpath("//xmlns:worksheet/@xml:space='preserve'"))
+    @ws.preserve_spaces = false
+    ws_xml = Nokogiri::XML(@ws.to_xml_string)
+    assert(!ws_xml.xpath("//xmlns:worksheet/@xml:space='preserve'"))
+  end
+
   def test_styles
     assert(@ws.styles.is_a?(Axlsx::Styles), 'worksheet provides access to styles')
   end


### PR DESCRIPTION
I encountered the same problem as issue #177 - namely that leading spaces were not preserved when opening the xlsx document.

This is fixed by adding the xml:space="preserve" attribute to the cell xml if it contains a leading or trailing space.
