### PR TITLE
Add a subtotal option to PivotTable.

### DIFF
--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -23,12 +23,9 @@ module Axlsx
       @columns = []
       @data = []
       @pages = []
-      @subtotal = 'sum'
       parse_options options
       yield self if block_given?
     end
-
-    attr_writer :subtotal
 
     # The reference to the table data
     # @return [String]
@@ -88,10 +85,17 @@ module Axlsx
     # (see #data)
     def data=(v)
       DataTypeValidator.validate "#{self.class}.data", [Array], v
-      v.each do |ref|
-        DataTypeValidator.validate "#{self.class}.data[]", [String], ref
+      @data = []
+      v.each do |data_field|
+        if data_field.is_a? String
+          data_field = {:ref => data_field}
+        end
+        data_field.values.each do |value|
+          DataTypeValidator.validate "#{self.class}.data[]", [String], value
+        end
+        @data << data_field
       end
-      @data = v
+      @data
     end
 
     # The pages
@@ -189,11 +193,11 @@ module Axlsx
         str << '</pageFields>'
       end
       unless data.empty?
-        str << '<dataFields count="' << data.size.to_s << '">'
+        str << "<dataFields count=\"#{data.size}\">"
         data.each do |datum_value|
-          str << "<dataField name=\"#{@subtotal} of " << datum_value << '" ' <<
-                            'fld="' << header_index_of(datum_value).to_s << '" ' <<
-                            'baseField="0" baseItem="0" subtotal="' << @subtotal << '"/>'
+          str << "<dataField name='#{@subtotal} of #{datum_value[:ref]}' fld='#{header_index_of(datum_value[:ref])}' baseField='0' baseItem='0'"
+          str << " subtotal='#{datum_value[:subtotal]}' " if datum_value[:subtotal]
+          str << "/>"
         end
         str << '</dataFields>'
       end


### PR DESCRIPTION
Hi,

I added an option to be able to specify the subtotal function for Pivot Table's data fields.

You may not want to merge it in the main branch as is since it lacks automated tests, but it works for me.
