### PR TITLE
Allow overriding the 'created' timestamp in the docprops.

### DIFF
--- a/lib/axlsx/doc_props/core.rb
+++ b/lib/axlsx/doc_props/core.rb
@@ -8,13 +8,18 @@ module Axlsx
  
     # Creates a new Core object.
     # @option options [String] creator
+    # @option options [Time] created
     def initialize(options={})
       @creator = options[:creator] || 'axlsx'
+      @created = options[:created]
     end
 
     # The author of the document. By default this is 'axlsx'
     # @return [String]
     attr_accessor :creator
+
+    # Creation time of the document. If nil, the current time will be used.
+    attr_accessor :created
 
     # serializes the core.xml document
     # @return [String]
@@ -24,7 +29,7 @@ module Axlsx
       str << 'xmlns:dcmitype="' << CORE_NS_DCMIT << '" xmlns:dcterms="' << CORE_NS_DCT << '" '
       str << 'xmlns:xsi="' << CORE_NS_XSI << '">'
       str << '<dc:creator>' << self.creator << '</dc:creator>'
-      str << '<dcterms:created xsi:type="dcterms:W3CDTF">' << Time.now.strftime('%Y-%m-%dT%H:%M:%S') << 'Z</dcterms:created>'
+      str << '<dcterms:created xsi:type="dcterms:W3CDTF">' << (created || Time.now).strftime('%Y-%m-%dT%H:%M:%S') << 'Z</dcterms:created>'
       str << '<cp:revision>0</cp:revision>'
       str << '</cp:coreProperties>'
     end

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -17,12 +17,14 @@ module Axlsx
     #
     # @param [Hash] options A hash that you can use to specify the author and workbook for this package.
     # @option options [String] :author The author of the document
+    # @option options [Time] :created_at Timestamp in the document properties (defaults to current time).
     # @option options [Boolean] :use_shared_strings This is passed to the workbook to specify that shared strings should be used when serializing the package.
     # @example Package.new :author => 'you!', :workbook => Workbook.new
     def initialize(options={})
       @workbook = nil
       @core, @app  =  Core.new, App.new
       @core.creator = options[:author] || @core.creator
+      @core.created = options[:created_at]
       parse_options options
       yield self if block_given?
     end

--- a/test/doc_props/tc_core.rb
+++ b/test/doc_props/tc_core.rb
@@ -23,6 +23,13 @@ class TestCore < Test::Unit::TestCase
     assert_equal(@doc.xpath('//dcterms:created').text, @time, "dcterms:created incorrect")
   end
 
+  def test_created_as_option
+    time = Time.utc(2013, 1, 1, 12, 00)
+    c = Axlsx::Core.new :created => time
+    doc = Nokogiri::XML(c.to_xml_string)
+    assert_equal(doc.xpath('//dcterms:created').text, time.xmlschema, "dcterms:created incorrect")
+  end
+
   def test_populates_default_name
     assert_equal(@doc.xpath('//dc:creator').text, "axlsx", "Default name not populated")
   end

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -105,6 +105,12 @@ class TestPackage < Test::Unit::TestCase
     assert(Axlsx::Package.new.workbook.worksheets.size == 0, 'Workbook should not have sheets by default')
   end
 
+  def test_created_at_is_propagated_to_core
+    time = Time.utc(2013, 1, 1, 12, 0)
+    p = Axlsx::Package.new :created_at => time
+    assert_equal(time, p.core.created)
+  end
+
   def test_serialization
     assert_nothing_raised do
       begin


### PR DESCRIPTION
Can be specified as option to Package#new:

``` ruby
Axlsx::Package.new :created_at => time
```

If omitted, the current time at the moment the document is serialized will be used. This change is therefore fully backward compatible.
