### PR TITLE
Axes reversed in Bar3DChart

### DIFF
--- a/lib/axlsx/drawing/bar_3D_chart.rb
+++ b/lib/axlsx/drawing/bar_3D_chart.rb
@@ -145,7 +145,7 @@ module Axlsx
     # category axes specified via axex[:val_axes] and axes[:cat_axis]
     # @return [Axes]
     def axes
-     @axes ||= Axes.new(:val_axis => ValAxis, :cat_axis => CatAxis)
+     @axes ||= Axes.new(:val_axis => CatAxis, :cat_axis => ValAxis)
     end
   end
 end


### PR DESCRIPTION
the `<c:axId val>` attributes generated by line 138 in `lib/axlsx/drawing/bar_3D_chart` were reversed, resulting in the labels showing up on the wrong axes.

It's not the most beautiful fix, but it works
