### PR TITLE
Color#rgb= mutates its argument

### DIFF
--- a/lib/axlsx/stylesheet/color.rb
+++ b/lib/axlsx/stylesheet/color.rb
@@ -51,7 +51,7 @@ module Axlsx
     # @see color
     def rgb=(v)
       Axlsx::validate_string(v)
-      v.upcase!
+      v = v.upcase
       v = v * 3 if v.size == 2
       v = v.rjust(8, 'FF')
       raise ArgumentError, "Invalid color rgb value: #{v}." unless v.match(/[0-9A-F]{8}/)

--- a/test/stylesheet/tc_color.rb
+++ b/test/stylesheet/tc_color.rb
@@ -27,6 +27,12 @@ class TestColor < Test::Unit::TestCase
     assert_equal(@item.rgb, "FF00FF00" )
   end
 
+  def test_rgb_writer_doesnt_mutate_its_argument
+    my_rgb = 'ff00ff00'
+    @item.rgb = my_rgb
+    assert_equal 'ff00ff00', my_rgb
+  end
+
   def test_tint
     assert_raise(ArgumentError) { @item.tint = -1 }
     assert_nothing_raised { @item.tint = -1.0 }


### PR DESCRIPTION
This could lead to hard-to-find bugs for users of the library and also (as in my case) raises an error if the user passes in a frozen object. Here's a fix.

Thanks for the library!
