### PR TITLE
upgrade to rubyzip 1.0.0

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files  = Dir.glob("{test/**/*}")
 
   s.add_runtime_dependency 'nokogiri', '>= 1.4.1'
-  s.add_runtime_dependency 'rubyzip', '>= 0.9.9'
+  s.add_runtime_dependency 'rubyzip', '>= 1.0.0'
   s.add_runtime_dependency "htmlentities", "~> 4.3.1"
 
   s.add_development_dependency 'yard'

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -23,7 +23,7 @@ require 'axlsx/workbook/workbook.rb'
 require 'axlsx/package.rb'
 #required gems
 require 'nokogiri'
-require 'zip/zip'
+require 'zip'
 
 #core dependencies
 require 'bigdecimal'
@@ -136,7 +136,7 @@ module Axlsx
     end
 
 
-  # Instructs the serializer to not try to escape cell value input. 
+  # Instructs the serializer to not try to escape cell value input.
   # This will give you a huge speed bonus, but if you content has <, > or other xml character data
   # the workbook will be invalid and excel will complain.
   def self.trust_input

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -70,7 +70,7 @@ module Axlsx
 
     #def self.parse(input, confirm_valid = false)
     #  p = Package.new
-    #  z = Zip::ZipFile.open(input)
+    #  z = Zip::File.open(input)
     #  p.workbook = Workbook.parse z.get_entry(WORKBOOK_PN)
     #  p
     #end
@@ -101,7 +101,7 @@ module Axlsx
     def serialize(output, confirm_valid=false)
       return false unless !confirm_valid || self.validate.empty?
       Relationship.clear_cached_instances
-      Zip::ZipOutputStream.open(output) do |zip|
+      Zip::OutputStream.open(output) do |zip|
         write_parts(zip)
       end
       true
@@ -114,7 +114,7 @@ module Axlsx
     def to_stream(confirm_valid=false)
       return false unless !confirm_valid || self.validate.empty?
       Relationship.clear_cached_instances
-      zip = write_parts(Zip::ZipOutputStream.new("streamed", true))
+      zip = write_parts(Zip::OutputStream.new("streamed", true))
       stream = zip.close_buffer
       stream.rewind
       stream
@@ -154,8 +154,8 @@ module Axlsx
     private
 
     # Writes the package parts to a zip archive.
-    # @param [Zip::ZipOutputStream] zip
-    # @return [Zip::ZipOutputStream]
+    # @param [Zip::OutputStream] zip
+    # @return [Zip::OutputStream]
     def write_parts(zip)
       p = parts
       p.each do |part|
@@ -173,8 +173,8 @@ module Axlsx
       zip
     end
 
-    # Generate a ZipEntry for the given package part.
-    # The important part here is to explicitly set the timestamp for the zip entry: Serializing axlsx packages 
+    # Generate a Entry for the given package part.
+    # The important part here is to explicitly set the timestamp for the zip entry: Serializing axlsx packages
     # with identical contents should result in identical zip files – however, the timestamp of a zip entry
     # defaults to the time of serialization and therefore the zip file contents would be different every time
     # the package is serialized.
@@ -183,12 +183,12 @@ module Axlsx
     # to set this explicitly, too (eg. with `Package.new(created_at: Time.local(2013, 1, 1))`).
     #
     # @param part A hash describing a part of this pacakge (see {#parts})
-    # @return [Zip::ZipEntry]
+    # @return [Zip::Entry]
     def zip_entry_for_part(part)
       timestamp = Zip::DOSTime.at(@core.created.to_i)
-      Zip::ZipEntry.new("", part[:entry], "", "", 0, 0, Zip::ZipEntry::DEFLATED, 0, timestamp)
+      Zip::Entry.new("", part[:entry], "", "", 0, 0, Zip::Entry::DEFLATED, 0, timestamp)
     end
-    
+
     # The parts of a package
     # @return [Array] An array of hashes that define the entry, document and schema for each part of the package.
     # @private

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -115,7 +115,7 @@ class TestPackage < Test::Unit::TestCase
     assert_nothing_raised do
       begin
         @package.serialize(@fname)
-        zf = Zip::ZipFile.open(@fname)
+        zf = Zip::File.open(@fname)
         @package.send(:parts).each{ |part| zf.get_entry(part[:entry]) }
         File.delete(@fname)
       rescue Errno::EACCES
@@ -123,7 +123,7 @@ class TestPackage < Test::Unit::TestCase
       end
     end
   end
-  
+
   # See comment for Package#zip_entry_for_part
   def test_serialization_creates_identical_files_at_any_time_if_created_at_is_set
     @package.core.created = Time.now
@@ -133,9 +133,9 @@ class TestPackage < Test::Unit::TestCase
       assert zip_content_then == zip_content_now, "zip files are not identical"
     end
   end
-  
+
   def test_serialization_creates_identical_files_for_identical_packages
-    package_1, package_2 = 2.times.map do 
+    package_1, package_2 = 2.times.map do
       Axlsx::Package.new(:created_at => Time.utc(2013, 1, 1)).tap do |p|
         p.workbook.add_worksheet(:name => "Basic Worksheet") do |sheet|
           sheet.add_row [1, 2, 3]


### PR DESCRIPTION
Axlsx is not compatible with the latest rubyzip release. This pull request updates the gemspec and makes axlsx work with rubyzip 1.0.0
