### PR TITLE
Add Cell#name

### DIFF
--- a/examples/split.rb
+++ b/examples/split.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby -w -s
+# -*- coding: utf-8 -*-
+$LOAD_PATH.unshift "#{File.dirname(__FILE__)}/../lib"
+require 'axlsx'
+p = Axlsx::Package.new
+wb = p.workbook
+wb.add_worksheet name: 'pane' do |sheet|
+  sheet.sheet_view.pane do |pane|
+    pane.top_left_cell = "B2"
+    pane.state = :frozen_split
+    pane.y_split = 2
+    pane.x_split = 1
+    pane.active_pane = :bottom_right
+  end
+end
+p.serialize 'pane.xlsx'

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -326,6 +326,18 @@ module Axlsx
       absolute ? r_abs : r
     end
 
+
+    # Creates a defined name in the workbook for this cell.
+    def name=(label)
+      row.worksheet.workbook.add_defined_name "#{row.worksheet.name}!#{r_abs}", name: label
+      @name = label
+    end
+
+    # returns the name of the cell
+    def name
+      @name
+    end
+
     private
 
     # we scale the font size if bold style is applied to either the style font or

--- a/test/workbook/worksheet/tc_cell.rb
+++ b/test/workbook/worksheet/tc_cell.rb
@@ -50,6 +50,12 @@ class TestCell < Test::Unit::TestCase
     assert_equal(@cAA.r_abs,"$AA$2", "needs to accept multi-digit columns")
   end
 
+  def test_name
+    @c.name = 'foo'
+    assert_equal(1, @ws.workbook.defined_names.size)
+    assert_equal('foo', @ws.workbook.defined_names.last.name)
+  end
+
   def test_style
     assert_raise(ArgumentError, "must reject invalid style indexes") { @c.style=@c.row.worksheet.workbook.styles.cellXfs.size }
     assert_nothing_raised("must allow valid style index changes") {@c.style=1}


### PR DESCRIPTION
Based on a recommendation from @thirdreplicator https://github.com/randym/axlsx/issues/241
This adds a name attribute to cell which when set will automatically create a defined name in the workbook allowing you to refer to that cell by its name in formula.
