### PR TITLE
Fix ScatterChart#y_val_axis returning the wrong axis

### DIFF
--- a/lib/axlsx/drawing/scatter_chart.rb
+++ b/lib/axlsx/drawing/scatter_chart.rb
@@ -25,7 +25,7 @@ module Axlsx
     # the y value axis
     # @return [ValAxis]
     def y_val_axis
-      axes[:x_val_axis]
+      axes[:y_val_axis]
     end
     alias :yValAxis :y_val_axis
 


### PR DESCRIPTION
The y_val_axis method was returning the x axis instead of the y axis.
