### PR TITLE
Remove error message on MS Excel 2010

### DIFF
--- a/lib/axlsx/content_type/content_type.rb
+++ b/lib/axlsx/content_type/content_type.rb
@@ -16,7 +16,6 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << "\r\n"
       str << '<Types xmlns="' << XML_NS_T << '">'
       each { |type| type.to_xml_string(str) }
       str << '</Types>'

--- a/lib/axlsx/content_type/content_type.rb
+++ b/lib/axlsx/content_type/content_type.rb
@@ -16,6 +16,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
+      str << "\r\n"
       str << '<Types xmlns="' << XML_NS_T << '">'
       each { |type| type.to_xml_string(str) }
       str << '</Types>'

--- a/lib/axlsx/drawing/bar_chart.rb
+++ b/lib/axlsx/drawing/bar_chart.rb
@@ -1,0 +1,96 @@
+module Axlsx
+
+  class BarChart < Chart
+
+    # the category axis
+    # @return [CatAxis]
+    def cat_axis
+      axes[:cat_axis]
+    end
+    alias :catAxis :cat_axis
+
+    # the value axis
+    # @return [ValAxis]
+    def val_axis
+      axes[:val_axis]
+    end
+    alias :valAxis :val_axis
+
+    # The direction of the bars in the chart
+    # must be one of [:bar, :col]
+    # @return [Symbol]
+    def bar_dir
+      @bar_dir ||= :bar
+    end
+    alias :barDir :bar_dir
+
+    #grouping for a column, line, or area chart.
+    # must be one of  [:percentStacked, :clustered, :standard, :stacked]
+    # @return [Symbol]
+    def grouping
+      @grouping ||= :clustered
+    end
+
+    # space between bar or column clusters, as a percentage of the bar or column width.
+    # @return [String]
+    def gap_width
+      @gap_width ||= 150
+    end
+    alias :gapWidth :gap_width
+
+    # validation regex for gap amount percent
+    GAP_AMOUNT_PERCENT = /0*(([0-9])|([1-9][0-9])|([1-4][0-9][0-9])|500)%/
+
+    def initialize(frame, options={})
+      @gap_width = nil
+      super(frame, options)
+      @series_type = BarSeries
+      @d_lbls = nil
+      @vary_colors = true
+    end
+
+    def to_xml_string(str = '')
+      super(str) do |str_inner|
+        str_inner << '<c:barChart>'
+        str_inner << '<c:barDir val="' << bar_dir.to_s << '"/>'
+        str_inner << '<c:grouping val="' << grouping.to_s << '"/>'
+        str_inner << '<c:varyColors val="' << vary_colors.to_s << '"/>'
+        @series.each { |ser| ser.to_xml_string(str_inner) }
+        @d_lbls.to_xml_string(str_inner) if @d_lbls
+        str_inner << '<c:gapWidth val="' << @gap_width.to_s << '"/>' unless @gap_width.nil?
+        axes.to_xml_string(str_inner, :ids => true)
+        str_inner << '</c:barChart>'
+        axes.to_xml_string(str_inner)
+      end
+    end
+
+    # The direction of the bars in the chart
+    # must be one of [:bar, :col]
+    def bar_dir=(v)
+      RestrictionValidator.validate "BarChart.bar_dir", [:bar, :col], v
+      @bar_dir = v
+    end
+    alias :barDir= :bar_dir=
+
+    #grouping for a column, line, or area chart.
+    # must be one of  [:percentStacked, :clustered, :standard, :stacked]
+    def grouping=(v)
+      RestrictionValidator.validate "BarChart.grouping", [:percentStacked, :clustered, :standard, :stacked], v
+      @grouping = v
+    end
+
+    # space between bar or column clusters, as a percentage of the bar or column width.
+    def gap_width=(v)
+      RegexValidator.validate "BarChart.gap_width", GAP_AMOUNT_PERCENT, v
+      @gap_width=(v)
+    end
+    alias :gapWidth= :gap_width=
+
+    # A hash of axes used by this chart. Bar charts have a value and
+    # category axes specified via axes[:val_axes] and axes[:cat_axis]
+    # @return [Axes]
+    def axes
+      @axes ||= Axes.new(:cat_axis => CatAxis, :val_axis => ValAxis)
+    end
+  end
+end

--- a/lib/axlsx/drawing/bar_series.rb
+++ b/lib/axlsx/drawing/bar_series.rb
@@ -53,6 +53,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       super(str) do |str_inner|
+        @legend_color = @colors.first
 
         colors.each_with_index do |c, index|
           str_inner << '<c:dPt>'

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -20,7 +20,6 @@ module Axlsx
       @graphic_frame.anchor.drawing.worksheet.workbook.charts << self
       @series = SimpleTypedList.new Series
       @show_legend = true
-      @show_title = true
       @display_blanks_as = :gap
       @series_type = Series
       @title = Title.new
@@ -72,9 +71,6 @@ module Axlsx
     # @return [Boolean]
     attr_reader :show_legend
 
-    # Show the title in the chart
-    # @return [Boolean]
-    attr_reader :show_title
 
     # How to display blank values
     # Options are
@@ -120,12 +116,6 @@ module Axlsx
     # @return [Boolean]
     def show_legend=(v) Axlsx::validate_boolean(v); @show_legend = v; end
 
-    # Show the title in the chart
-    # @param [Boolean] v
-    # @return [Boolean]
-    def show_title=(v) Axlsx::validate_boolean(v); @show_title = v; end
-
-
     # How to display blank values
     # @see display_blanks_as
     # @param [Symbol] v
@@ -168,9 +158,7 @@ module Axlsx
       str << '<c:date1904 val="' << Axlsx::Workbook.date1904.to_s << '"/>'
       str << '<c:style val="' << style.to_s << '"/>'
       str << '<c:chart>'
-      if @show_title
-        @title.to_xml_string str
-      end
+      @title.to_xml_string str
       str << '<c:autoTitleDeleted val="' << (@title == nil).to_s << '"/>'
       @view_3D.to_xml_string(str) if @view_3D
       str << '<c:floor><c:thickness val="0"/></c:floor>'

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -177,9 +177,9 @@ module Axlsx
       str << '<c:showDLblsOverMax val="1"/>'
       str << '</c:chart>'
       str << '<c:printSettings>'
-      str << '<c:headerFooter/>'
+#      str << '<c:headerFooter/>'
       str << '<c:pageMargins b="1.0" l="0.75" r="0.75" t="1.0" header="0.5" footer="0.5"/>'
-      str << '<c:pageSetup/>'
+#      str << '<c:pageSetup/>'
       str << '</c:printSettings>'
       str << '</c:chartSpace>'
     end

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -150,7 +150,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<?xml version="1.0" encoding="UTF-8"?>'
+      str << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
       str << '<c:chartSpace xmlns:c="' << XML_NS_C << '" xmlns:a="' << XML_NS_A << '" xmlns:r="' << XML_NS_R << '">'
       str << '<c:date1904 val="' << Axlsx::Workbook.date1904.to_s << '"/>'
       str << '<c:style val="' << style.to_s << '"/>'

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -20,6 +20,7 @@ module Axlsx
       @graphic_frame.anchor.drawing.worksheet.workbook.charts << self
       @series = SimpleTypedList.new Series
       @show_legend = true
+      @show_title = true
       @display_blanks_as = :gap
       @series_type = Series
       @title = Title.new
@@ -71,6 +72,10 @@ module Axlsx
     # @return [Boolean]
     attr_reader :show_legend
 
+    # Show the title in the chart
+    # @return [Boolean]
+    attr_reader :show_title
+
     # How to display blank values
     # Options are
     # * gap:  Display nothing
@@ -115,6 +120,12 @@ module Axlsx
     # @return [Boolean]
     def show_legend=(v) Axlsx::validate_boolean(v); @show_legend = v; end
 
+    # Show the title in the chart
+    # @param [Boolean] v
+    # @return [Boolean]
+    def show_title=(v) Axlsx::validate_boolean(v); @show_title = v; end
+
+
     # How to display blank values
     # @see display_blanks_as
     # @param [Symbol] v
@@ -146,6 +157,8 @@ module Axlsx
       @series.last
     end
 
+
+
     # Serializes the object
     # @param [String] str
     # @return [String]
@@ -155,7 +168,9 @@ module Axlsx
       str << '<c:date1904 val="' << Axlsx::Workbook.date1904.to_s << '"/>'
       str << '<c:style val="' << style.to_s << '"/>'
       str << '<c:chart>'
-      @title.to_xml_string str
+      if @show_title
+        @title.to_xml_string str
+      end
       str << '<c:autoTitleDeleted val="' << (@title == nil).to_s << '"/>'
       @view_3D.to_xml_string(str) if @view_3D
       str << '<c:floor><c:thickness val="0"/></c:floor>'

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -14,15 +14,16 @@ module Axlsx
     # @option options [Array|String|Cell] start_at The X, Y coordinates defining the top left corner of the chart.
     # @option options [Array|String|Cell] end_at The X, Y coordinates defining the bottom right corner of the chart.
     def initialize(frame, options={})
-      @style = 18
-      @view_3D = nil
+      @style        = 18
+      @view_3D      = nil
       @graphic_frame=frame
       @graphic_frame.anchor.drawing.worksheet.workbook.charts << self
-      @series = SimpleTypedList.new Series
-      @show_legend = true
+      @series            = SimpleTypedList.new Series
+      @show_legend       = true
       @display_blanks_as = :gap
-      @series_type = Series
-      @title = Title.new
+      @series_type       = Series
+      @title             = Title.new
+      @bg_color          = nil
       parse_options options
       start_at(*options[:start_at]) if options[:start_at]
       end_at(*options[:end_at]) if options[:end_at]
@@ -53,10 +54,16 @@ module Axlsx
     # Indicates that colors should be varied by datum
     # @return [Boolean]
     attr_reader :vary_colors
- 
+
     # Configures the vary_colors options for this chart
     # @param [Boolean] v The value to set
-    def vary_colors=(v) Axlsx::validate_boolean(v); @vary_colors = v; end
+    def vary_colors=(v)
+      Axlsx::validate_boolean(v); @vary_colors = v;
+    end
+
+    # the background color for chart
+    # @return [String]
+    attr_reader :bg_color
 
     # The title object for the chart.
     # @return [Title]
@@ -99,6 +106,11 @@ module Axlsx
       "#{CHART_PN % (index+1)}"
     end
 
+    # @see color
+    def bg_color=(v)
+      @bg_color = v
+    end
+
     # The title object for the chart.
     # @param [String, Cell] v
     # @return [Title]
@@ -114,18 +126,24 @@ module Axlsx
     # Show the legend in the chart
     # @param [Boolean] v
     # @return [Boolean]
-    def show_legend=(v) Axlsx::validate_boolean(v); @show_legend = v; end
+    def show_legend=(v)
+      Axlsx::validate_boolean(v); @show_legend = v;
+    end
 
     # How to display blank values
     # @see display_blanks_as
     # @param [Symbol] v
     # @return [Symbol]
-    def display_blanks_as=(v) Axlsx::validate_display_blanks_as(v); @display_blanks_as = v; end
+    def display_blanks_as=(v)
+      Axlsx::validate_display_blanks_as(v); @display_blanks_as = v;
+    end
 
     # The style for the chart.
     # see ECMA Part 1 §21.2.2.196
     # @param [Integer] v must be between 1 and 48
-    def style=(v) DataTypeValidator.validate "Chart.style", Integer, v, lambda { |arg| arg >= 1 && arg <= 48 }; @style = v; end
+    def style=(v)
+      DataTypeValidator.validate "Chart.style", Integer, v, lambda { |arg| arg >= 1 && arg <= 48 }; @style = v;
+    end
 
     # backwards compatibility to allow chart.to and chart.from access to anchor markers
     # @note This will be disconinued in version 2.0.0. Please use the end_at method
@@ -146,7 +164,6 @@ module Axlsx
       @series_type.new(self, options)
       @series.last
     end
-
 
 
     # Serializes the object
@@ -179,6 +196,14 @@ module Axlsx
       str << '<c:dispBlanksAs val="' << display_blanks_as.to_s << '"/>'
       str << '<c:showDLblsOverMax val="1"/>'
       str << '</c:chart>'
+      # chart background
+      if @bg_color
+        str << '<c:spPr>'
+        str << '<a:solidFill>'
+        str << '<a:srgbClr val="' << @bg_color << '"/>'
+        str << '</a:solidFill>'
+        str << '</c:spPr>'
+      end
       str << '<c:printSettings>'
       str << '<c:headerFooter/>'
       str << '<c:pageMargins b="1.0" l="0.75" r="0.75" t="1.0" header="0.5" footer="0.5"/>'
@@ -227,7 +252,10 @@ module Axlsx
     end
 
     # sets the view_3D object for the chart
-    def view_3D=(v) DataTypeValidator.validate "#{self.class}.view_3D", View3D, v; @view_3D = v; end
+    def view_3D=(v)
+      DataTypeValidator.validate "#{self.class}.view_3D", View3D, v; @view_3D = v;
+    end
+
     alias :view3D= :view_3D=
 
   end

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -150,7 +150,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+      str << '<?xml version="1.0" encoding="UTF-8"?>'
       str << '<c:chartSpace xmlns:c="' << XML_NS_C << '" xmlns:a="' << XML_NS_A << '" xmlns:r="' << XML_NS_R << '">'
       str << '<c:date1904 val="' << Axlsx::Workbook.date1904.to_s << '"/>'
       str << '<c:style val="' << style.to_s << '"/>'

--- a/lib/axlsx/drawing/drawing.rb
+++ b/lib/axlsx/drawing/drawing.rb
@@ -34,6 +34,7 @@ module Axlsx
   require 'axlsx/drawing/view_3D.rb'
   require 'axlsx/drawing/chart.rb'
   require 'axlsx/drawing/pie_3D_chart.rb'
+  require 'axlsx/drawing/bar_chart.rb'
   require 'axlsx/drawing/bar_3D_chart.rb'
   require 'axlsx/drawing/line_chart.rb'
   require 'axlsx/drawing/line_3D_chart.rb'

--- a/lib/axlsx/drawing/drawing.rb
+++ b/lib/axlsx/drawing/drawing.rb
@@ -154,7 +154,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+      str << '<?xml version="1.0" encoding="UTF-8"?>'
       str << '<xdr:wsDr xmlns:xdr="' << XML_NS_XDR << '" xmlns:a="' << XML_NS_A << '">'
       anchors.each { |anchor| anchor.to_xml_string(str) }
       str << '</xdr:wsDr>'

--- a/lib/axlsx/drawing/line_series.rb
+++ b/lib/axlsx/drawing/line_series.rb
@@ -71,7 +71,7 @@ module Axlsx
           str << '<a:srgbClr val="' << color << '"/>'
           str << '</a:solidFill>'
           str << '</a:ln>'
-          str << '<a:round/>'
+          # str << '<a:round/>'
           str << '</c:spPr>'
         end
         str << '<c:marker><c:symbol val="none"/></c:marker>' unless @show_marker

--- a/lib/axlsx/drawing/series.rb
+++ b/lib/axlsx/drawing/series.rb
@@ -75,8 +75,8 @@ module Axlsx
 
     #set trenline_weight
     def trendline_weight
-      if @trendline[:weight].to_s
-      @trendline[:weight].to_s
+      if @trendline[:weight]
+        @trendline[:weight].to_s
       else
         '1'
       end
@@ -109,18 +109,18 @@ module Axlsx
       end
 
       if @trendline
-        str << ' <c:trendline>'
-        str << ' <c:spPr>'
-        str << ' <a:ln w="' << trendline_weight << '8100">'
-        str << ' <a:solidFill>'
-        str << ' <a:srgbClr val="' << trendline_color << '"/>'
-        str << ' </a:solidFill>'
-        str << '       </a:ln>'
-        str << ' </c:spPr>'
-        str << '     <c:trendlineType val="linear"/>'
-        str << ' <c:dispRSqr val="0"/>'
-        str << ' <c:dispEq val="0"/>'
-        str << ' </c:trendline>'
+        str << '<c:trendline>'
+        str << '<c:spPr>'
+        str << '<a:ln w="' << trendline_weight << '">'
+        str << '<a:solidFill>'
+        str << '<a:srgbClr val="' << trendline_color << '"/>'
+        str << '</a:solidFill>'
+        str << '</a:ln>'
+        str << '</c:spPr>'
+        str << '<c:trendlineType val="linear"/>'
+        str << '<c:dispRSqr val="0"/>'
+        str << '<c:dispEq val="0"/>'
+        str << '</c:trendline>'
       end
       str << '</c:ser>'
     end

--- a/lib/axlsx/drawing/series.rb
+++ b/lib/axlsx/drawing/series.rb
@@ -20,12 +20,16 @@ module Axlsx
     # @return [String]
     attr_reader :legend_color
 
+    #The Hash of trendline options
+    # @return [Hash]
+    attr_reader :trendline
+
     # Creates a new series
     # @param [Chart] chart
     # @option options [Integer] order
     # @option options [String] title
     def initialize(chart, options={})
-      @order = nil
+      @order     = nil
       self.chart = chart
       @chart.series << self
       parse_options options
@@ -44,7 +48,9 @@ module Axlsx
     end
 
     # @see order
-    def order=(v)  Axlsx::validate_unsigned_int(v); @order = v; end
+    def order=(v)
+      Axlsx::validate_unsigned_int(v); @order = v;
+    end
 
     # @see title
     def title=(v)
@@ -53,10 +59,36 @@ module Axlsx
       @title = v
     end
 
+    # @see trendline
+    def trendline=(v)
+      @trendline = v
+    end
+
+    # set trendline_color
+    def trendline_color
+      if @trendline[:color]
+        @trendline[:color]
+      else
+        '00000'
+      end
+    end
+
+    #set trenline_weight
+    def trendline_weight
+      if @trendline[:weight].to_s
+      @trendline[:weight].to_s
+      else
+        '1'
+      end
+
+    end
+
     private
 
     # assigns the chart for this series
-    def chart=(v)  DataTypeValidator.validate "Series.chart", Chart, v; @chart = v; end
+    def chart=(v)
+      DataTypeValidator.validate "Series.chart", Chart, v; @chart = v;
+    end
 
     # Serializes the object
     # @param [String] str
@@ -68,12 +100,27 @@ module Axlsx
       title.to_xml_string(str) unless title.nil?
       yield str if block_given?
       #set color at legend
-     if @legend_color
+      if @legend_color
         str << '<c:spPr>'
         str << '<a:solidFill>'
         str << '<a:srgbClr val="'<< legend_color.to_s << '"/>'
         str << '</a:solidFill>'
         str << '</c:spPr>'
+      end
+
+      if @trendline
+        str << ' <c:trendline>'
+        str << ' <c:spPr>'
+        str << ' <a:ln w="' << trendline_weight << '8100">'
+        str << ' <a:solidFill>'
+        str << ' <a:srgbClr val="' << trendline_color << '"/>'
+        str << ' </a:solidFill>'
+        str << '       </a:ln>'
+        str << ' </c:spPr>'
+        str << '     <c:trendlineType val="linear"/>'
+        str << ' <c:dispRSqr val="0"/>'
+        str << ' <c:dispEq val="0"/>'
+        str << ' </c:trendline>'
       end
       str << '</c:ser>'
     end

--- a/lib/axlsx/drawing/series.rb
+++ b/lib/axlsx/drawing/series.rb
@@ -16,6 +16,10 @@ module Axlsx
     # @return [SeriesTitle]
     attr_reader :title
 
+    # The String of rgb color to apply to chart legend
+    # @return [String]
+    attr_reader :legend_color
+
     # Creates a new series
     # @param [Chart] chart
     # @option options [Integer] order
@@ -63,6 +67,14 @@ module Axlsx
       str << '<c:order val="' << (order || index).to_s << '"/>'
       title.to_xml_string(str) unless title.nil?
       yield str if block_given?
+      #set color at legend
+     if @legend_color
+        str << '<c:spPr>'
+        str << '<a:solidFill>'
+        str << '<a:srgbClr val="'<< legend_color.to_s << '"/>'
+        str << '</a:solidFill>'
+        str << '</c:spPr>'
+      end
       str << '</c:ser>'
     end
   end

--- a/lib/axlsx/drawing/title.rb
+++ b/lib/axlsx/drawing/title.rb
@@ -43,8 +43,8 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<c:title>'
       unless @text.empty?
+        str << '<c:title>'
         str << '<c:tx>'
         if @cell.is_a?(Cell)
           str << '<c:strRef>'
@@ -68,11 +68,10 @@ module Axlsx
           str << '</c:rich>'
         end
         str << '</c:tx>'
-      end
       str << '<c:layout/>'
       str << '<c:overlay val="0"/>'
       str << '</c:title>'
+      end
     end
-
   end
 end

--- a/lib/axlsx/workbook/worksheet/header_footer.rb
+++ b/lib/axlsx/workbook/worksheet/header_footer.rb
@@ -42,13 +42,18 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << "<headerFooter "
-      serialized_attributes str
-      str << ">"
-      serialized_element_attributes(str) do |value|
+      cstr = ''
+      cstr << "<headerFooter "
+      serialized_attributes cstr
+      cstr << ">"
+      serialized_element_attributes(cstr) do |value|
         value = ::CGI.escapeHTML(value)
       end
-      str << "</headerFooter>"
+      cstr << "</headerFooter>"
+      if cstr != '<headerFooter ></headerFooter>'
+        str << cstr
+      end
+      str
     end
   end
 end

--- a/lib/axlsx/workbook/worksheet/page_setup.rb
+++ b/lib/axlsx/workbook/worksheet/page_setup.rb
@@ -234,9 +234,14 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<pageSetup '
-      serialized_attributes str
-      str << '/>'
+      cstr = ''
+      cstr << '<pageSetup '
+      serialized_attributes cstr
+      cstr << '/>'
+      if cstr != '<pageSetup />'
+        str << cstr
+      end
+      str
     end
   end
 end

--- a/test/drawing/tc_bar_chart.rb
+++ b/test/drawing/tc_bar_chart.rb
@@ -1,0 +1,58 @@
+require 'tc_helper.rb'
+require 'axlsx/drawing/bar_chart'
+
+class TestBarChart < Test::Unit::TestCase
+
+  def setup
+    @p = Axlsx::Package.new
+    ws = @p.workbook.add_worksheet
+    @row = ws.add_row ["one", 1, Time.new]
+    @chart = ws.add_chart Axlsx::BarChart, :title => "fishery", :bar_dir => :col
+  end
+
+  def test_initialization
+    assert_equal(@chart.series_type, Axlsx::BarSeries, "series type incorrect")
+  end
+
+  def test_chart_type
+    doc = Nokogiri::XML(@chart.to_xml_string)
+    assert_equal(1, doc.xpath('//c:barChart').size)
+  end
+
+  def test_bar_direction
+    assert_raise(ArgumentError, "require valid bar direction") { @chart.bar_dir = :left }
+    assert_nothing_raised("allow valid bar direction") { @chart.bar_dir = :col }
+    assert(@chart.bar_dir == :col)
+  end
+
+  def test_grouping
+    assert_raise(ArgumentError, "require valid grouping") { @chart.grouping = :inverted }
+    assert_nothing_raised("allow valid grouping") { @chart.grouping = :standard }
+    assert(@chart.grouping == :standard)
+  end
+
+  def test_gapWidth
+    assert_raise(ArgumentError, "require valid gap width") { @chart.gap_width = 200 }
+    assert_nothing_raised("allow valid gapWidth") { @chart.gap_width = "200%" }
+    assert(@chart.gap_width == "200%")
+  end
+
+  def test_to_xml_string
+    schema = Nokogiri::XML::Schema(File.open(Axlsx::DRAWING_XSD))
+    doc = Nokogiri::XML(@chart.to_xml_string)
+    errors = []
+    schema.validate(doc).each do |error|
+      errors.push error
+      puts error.message
+    end
+    assert(errors.empty?, "error free validation")
+  end
+
+  def test_to_xml_string_has_axes_in_correct_order
+    str = @chart.to_xml_string
+    cat_axis_position = str.index(@chart.axes[:cat_axis].id.to_s)
+    val_axis_position = str.index(@chart.axes[:val_axis].id.to_s)
+    assert(cat_axis_position < val_axis_position, "cat_axis must occur earlier than val_axis in the XML")
+  end
+
+end

--- a/test/drawing/tc_chart.rb
+++ b/test/drawing/tc_chart.rb
@@ -35,6 +35,11 @@ class TestChart < Test::Unit::TestCase
     assert_equal(0, doc.xpath('//a:t').size)
   end
 
+  def test_bg_color
+    doc = Nokogiri::XML(@chart.to_xml_string)
+    assert_equal(0, doc.xpath('//a:t', 'a:solidFill').size)
+  end
+
   def test_to_from_marker_access
     assert(@chart.to.is_a?(Axlsx::Marker))
     assert(@chart.from.is_a?(Axlsx::Marker))

--- a/test/drawing/tc_chart.rb
+++ b/test/drawing/tc_chart.rb
@@ -28,8 +28,8 @@ class TestChart < Test::Unit::TestCase
   end
 
   def test_hidden_title
-    # das ist der code, der Fehlen soll
-    # <a:t>fishery</a:t>
+    # this code must be missing
+    # <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>fishery</a:t></a:r></a:p></c:rich></c:tx>
     @chart.show_title = false
     doc = Nokogiri::XML(@chart.to_xml_string)
     assert_equal(0, doc.xpath('//a:t[text()="fishery"]').size)

--- a/test/drawing/tc_chart.rb
+++ b/test/drawing/tc_chart.rb
@@ -27,6 +27,14 @@ class TestChart < Test::Unit::TestCase
     assert_equal(@chart.title.cell, @row.cells.first)
   end
 
+  def test_hidden_title
+    # das ist der code, der Fehlen soll
+    # <a:t>fishery</a:t>
+    @chart.show_title = false
+    doc = Nokogiri::XML(@chart.to_xml_string)
+    assert_equal(0, doc.xpath('//a:t[text()="fishery"]').size)
+  end
+
   def test_to_from_marker_access
     assert(@chart.to.is_a?(Axlsx::Marker))
     assert(@chart.from.is_a?(Axlsx::Marker))
@@ -37,7 +45,7 @@ class TestChart < Test::Unit::TestCase
     assert_nothing_raised { @chart.style = 2 }
     assert_equal(@chart.style, 2)
   end
-  
+
   def test_vary_colors
     assert_equal(true, @chart.vary_colors)
     assert_raise(ArgumentError) { @chart.vary_colors = 7 }

--- a/test/drawing/tc_chart.rb
+++ b/test/drawing/tc_chart.rb
@@ -6,13 +6,14 @@ class TestChart < Test::Unit::TestCase
     @p = Axlsx::Package.new
     ws = @p.workbook.add_worksheet
     @row = ws.add_row ["one", 1, Time.now]
-    @chart = ws.add_chart Axlsx::Bar3DChart, :title => "fishery"
+    @chart = ws.add_chart Axlsx::Bar3DChart
   end
 
   def teardown
   end
 
   def test_initialization
+    @chart.title = 'fishery'
     assert_equal(@p.workbook.charts.last,@chart, "the chart is in the workbook")
     assert_equal(@chart.title.text, "fishery", "the title option has been applied")
     assert((@chart.series.is_a?(Axlsx::SimpleTypedList) && @chart.series.empty?), "The series is initialized and empty")
@@ -30,9 +31,8 @@ class TestChart < Test::Unit::TestCase
   def test_hidden_title
     # this code must be missing
     # <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>fishery</a:t></a:r></a:p></c:rich></c:tx>
-    @chart.show_title = false
     doc = Nokogiri::XML(@chart.to_xml_string)
-    assert_equal(0, doc.xpath('//a:t[text()="fishery"]').size)
+    assert_equal(0, doc.xpath('//a:t').size)
   end
 
   def test_to_from_marker_access


### PR DESCRIPTION
Excel says the file is corrupted if the XML contains empty xml nodes.
Those modifications try to no emit xml nodes if they are empty.
