### PR TITLE
[#280] Updates rubyzip dependency

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files  = Dir.glob("{test/**/*}")
 
   s.add_runtime_dependency 'nokogiri', '>= 1.4.1'
-  s.add_runtime_dependency 'rubyzip', '~> 1.0.0'
+  s.add_runtime_dependency 'rubyzip', '~> 1.1.0'
   s.add_runtime_dependency "htmlentities", "~> 4.3.1"
 
   s.add_development_dependency 'yard'


### PR DESCRIPTION
Hello,
I noticed a bug in version 1.0.0 of rubyzip that was fixed in a later release. axlsx still uses the buggy version which prevents me from updating the rubyzip gem.

The bug i was talking about:
rubyzip/rubyzip@v1.0.0...v1.1.0#diff-b2465821a9969effeacd35f1d69e18e6L118
