### PR TITLE
Do not camelize underscores on DefinedNames

### DIFF
--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -121,10 +121,10 @@ module Axlsx
   # performs the increadible feat of changing snake_case to CamelCase
   # @param [String] s The snake case string to camelize
   # @return [String]
-  def self.camel(s="", all_caps = true)
+  def self.camel(s="", all_caps = true, camel_underscores = true)
     s = s.to_s
     s = s.capitalize if all_caps
-    s.gsub(/_(.)/){ $1.upcase }
+    camel_underscores ? s.gsub(/_(.)/){ $1.upcase } : s
   end
 
     # returns the provided string with all invalid control charaters

--- a/lib/axlsx/util/serialized_attributes.rb
+++ b/lib/axlsx/util/serialized_attributes.rb
@@ -11,7 +11,7 @@ module Axlsx
     # class methods applied to all includers
     module ClassMethods
 
-      # This is the method to be used in inheriting classes to specify 
+      # This is the method to be used in inheriting classes to specify
       # which of the instance values are serializable
       def serializable_attributes(*symbols)
         @xml_attributes = symbols
@@ -33,16 +33,16 @@ module Axlsx
       end
     end
 
-    # serializes the instance values of the defining object based on the 
+    # serializes the instance values of the defining object based on the
     # list of serializable attributes.
     # @param [String] str The string instance to append this
     # serialization to.
     # @param [Hash] additional_attributes An option key value hash for
     # defining values that are not serializable attributes list.
-    def serialized_attributes(str = '', additional_attributes = {})
+    def serialized_attributes(str = '', additional_attributes = {}, camel_underscores = true)
       attributes = declared_attributes.merge! additional_attributes
       attributes.each do |key, value|
-        str << "#{Axlsx.camel(key, false)}=\"#{Axlsx.camel(value, false)}\" "
+        str << "#{Axlsx.camel(key, false, camel_underscores)}=\"#{Axlsx.camel(value, false, camel_underscores)}\" "
       end
       str
     end

--- a/lib/axlsx/workbook/defined_name.rb
+++ b/lib/axlsx/workbook/defined_name.rb
@@ -24,16 +24,16 @@
 # </xsd:simpleContent>
 
 module Axlsx
-  # This element defines the defined names that are defined within this workbook. 
+  # This element defines the defined names that are defined within this workbook.
   # Defined names are descriptive text that is used to represents a cell, range of cells, formula, or constant value.
   # Use easy-to-understand names, such as Products, to refer to hard to understand ranges, such as Sales!C20:C30.
-  # A defined name in a formula can make it easier to understand the purpose of the formula. 
+  # A defined name in a formula can make it easier to understand the purpose of the formula.
   # @example
   #     The formula =SUM(FirstQuarterSales) might be easier to identify than =SUM(C20:C30
   #
   # Names are available to any sheet.
   # @example
-  #     If the name ProjectedSales refers to the range A20:A30 on the first worksheet in a workbook, 
+  #     If the name ProjectedSales refers to the range A20:A30 on the first worksheet in a workbook,
   #     you can use the name ProjectedSales on any other sheet in the same workbook to refer to range A20:A30 on the first worksheet.
   # Names can also be used to represent formulas or values that do not change (constants).
   #
@@ -71,7 +71,7 @@ module Axlsx
     #                                         applied. This represents the source data range, unfiltered.
     #                                      b. This defined name refers to a range to which an AutoFilter has been
     #                                         applied.
-    #                           _xlnm.Extract: this defined name refers to the range containing the filtered output 
+    #                           _xlnm.Extract: this defined name refers to the range containing the filtered output
     #                                           values resulting from applying an advanced filter criteria to a source range.
     #                         Miscellaneous
     #                           _xlnm.Consolidate_Area: the defined name refers to a consolidation area.
@@ -88,14 +88,14 @@ module Axlsx
     #                             This attribute is used when there is an add-in or other code project associated with the file.
     # @option [Boolean] vb_proceedure - Specifies a boolean value that indicates whether the defined name is related to an external function, command, or other executable code.
     # @option [Boolean] xlm - Specifies a boolean value that indicates whether the defined name is related to an external function, command, or other executable code.
-    # @option [Integer] function_group_id - Specifies the function group index if the defined name refers to a function. 
+    # @option [Integer] function_group_id - Specifies the function group index if the defined name refers to a function.
     #                                       The function group defines the general category for the function.
     #                                       This attribute is used when there is an add-in or other code project associated with the file.
     #                                       See Open Office XML Part 1 for more info.
     # @option [String] short_cut_key - Specifies the keyboard shortcut for the defined name.
-    # @option [Boolean] publish_to_server - Specifies a boolean value that indicates whether the defined name is included in the 
+    # @option [Boolean] publish_to_server - Specifies a boolean value that indicates whether the defined name is included in the
     #                                       version of the workbook that is published to or rendered on a Web or application server.
-    # @option [Boolean] workbook_parameter - Specifies a boolean value that indicates that the name is used as a workbook parameter on a 
+    # @option [Boolean] workbook_parameter - Specifies a boolean value that indicates that the name is used as a workbook parameter on a
     #                                        version of the workbook that is published to or rendered on a Web or application server.
     def initialize(formula, options={})
       @formula = formula
@@ -119,9 +119,9 @@ module Axlsx
       :workbook_parameter, :publish_to_server, :xlm, :vb_proceedure, :function, :hidden, :name, :local_sheet_id
 
     def to_xml_string(str='')
-      raise ArgumentError, 'you must specify the name for this defined name. Please read the documentation for Axlsx::DefinedName for more details' unless name 
+      raise ArgumentError, 'you must specify the name for this defined name. Please read the documentation for Axlsx::DefinedName for more details' unless name
       str << '<definedName '
-      serialized_attributes str
+      serialized_attributes(str, {}, false)
       str << '>' << @formula
       str << '</definedName>'
     end

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -367,7 +367,7 @@ module Axlsx
     def auto_filter=(v)
       DataTypeValidator.validate "Worksheet.auto_filter", String, v
       auto_filter.range = v
-      workbook.add_defined_name auto_filter.defined_name, name: '_xlnm.FilterDatabase', local_sheet_id: index, hidden: 1
+      workbook.add_defined_name auto_filter.defined_name, name: '_xlnm._FilterDatabase', local_sheet_id: index, hidden: 1
     end
 
     # Accessor for controlling whether leading and trailing spaces in cells are

--- a/test/workbook/tc_defined_name.rb
+++ b/test/workbook/tc_defined_name.rb
@@ -1,14 +1,14 @@
 require 'tc_helper'
 
 class TestDefinedNames < Test::Unit::TestCase
-  def setup 
+  def setup
     @dn = Axlsx::DefinedName.new('Sheet1!A1:A1')
   end
 
   def test_initialize
     assert_equal('Sheet1!A1:A1', @dn.formula)
   end
-  
+
   def test_string_attributes
     %w(short_cut_key status_bar help description custom_menu comment).each do |attr|
       assert_raise(ArgumentError, 'only strings allowed in string attributes') { @dn.send("#{attr}=", 1) }
@@ -33,9 +33,24 @@ class TestDefinedNames < Test::Unit::TestCase
     assert_raise(ArgumentError, 'name is required for serialization') { @dn.to_xml_string }
     @dn.name = '_xlnm.Print_Titles'
     @dn.hidden = true
+
+    assert(node_present("//definedName[@name='_xlnm.Print_Titles']"))
+    assert(node_present("//definedName[@hidden='true']"))
+    assert_equal('Sheet1!A1:A1', node('//definedName').text)
+  end
+
+  def test_do_not_camel_names
+    @dn.name = '_xlnm._FilterDatabase'
+    assert(node_present("//definedName[@name='_xlnm._FilterDatabase']"))
+    assert(!node_present("//definedName[@name='Xlnm.FilterDatabase']"))
+  end
+
+  def node(selector)
     doc = Nokogiri::XML(@dn.to_xml_string)
-    assert(doc.xpath("//definedName[@name='_xlnm.Print_Titles']"))
-    assert(doc.xpath("//definedName[@hidden='true']"))
-    assert_equal('Sheet1!A1:A1', doc.xpath('//definedName').text)
+    doc.xpath(selector)
+  end
+
+  def node_present(selector)
+    !node(selector).empty?
   end
 end


### PR DESCRIPTION
Recently I've stumbled upon the bug in current axlsx that prevents simple enough auto_filter from working (taken from the [gist](https://gist.github.com/randym/3179305)):

``` ruby
wb.add_worksheet(:name => "Auto Filter") do |sheet|
  sheet.add_row ["Build Matrix"]
  sheet.add_row ["Build", "Duration", "Finished", "Rvm"]
  sheet.add_row ["19.1", "1 min 32 sec", "about 10 hours ago", "1.8.7"]
  sheet.add_row ["19.2", "1 min 28 sec", "about 10 hours ago", "1.9.2"]
  sheet.add_row ["19.3", "1 min 35 sec", "about 10 hours ago", "1.9.3"]
  sheet.auto_filter = "A2:D5"
end
```

The code above generates the example file successfully, however, trying to do sorting in auto filter makes Excel crash. This is 100% reproducible on MS Office 11 for Mac v. 14.3.9.

I've spent some considerable time to track it down, but long story short is that according to the [comment](https://github.com/randym/axlsx/issues/57#issuecomment-4655851) in #57, in order for auto_filter to work, the DefinedName should be added to workbook.xml, i.e

``` xml
<definedNames>
  <definedName name="_xlnm._FilterDatabase" localSheetId="0" hidden="1">Table!$A$2:$D$5</definedName>
</definedNames>
```

Current Axlsx attribute serialization is trying to camelize attribute names, which makes the code above to render as 

``` xml
<definedNames>
  <definedName name="Xlnm.FilterDatabase" localSheetId="0" hidden="1">Table!$A$2:$D$5</definedName>
</definedNames>
```

and thus breaks the auto_filter functionality.

The proposed fix turns off camelization for DefinedNames. This fixes crashing auto_filter and potentially other issues related to DefinedNames. Tests included.
