### PR TITLE
add support for streaming while rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ cell level input data validation.
 
 13. Export using shared strings or inline strings so we can inter-op with iWork Numbers (sans charts for now).
 
-14. Output to file or StringIO
+14. Output to file or StringIO or Stream
 
 15. Support for page margins and print options
 

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -11,6 +11,10 @@ require 'axlsx/util/options_parser'
 # to be included with parsable intitites.
 #require 'axlsx/util/parser.rb'
 
+require 'axlsx/streaming/fake_io.rb'
+require 'axlsx/streaming/output_stream.rb'
+require 'axlsx/streaming/zip_body.rb'
+
 require 'axlsx/stylesheet/styles.rb'
 
 require 'axlsx/doc_props/app.rb'
@@ -149,4 +153,17 @@ module Axlsx
   def self.trust_input=(trust_me)
     @trust_input = trust_me
   end
+
+  # Allows lazy fetching of worksheet rows at render time
+  def self.lazy_row_fetching
+    @lazy_row_fetching ||= false
+  end
+
+  # @param[Boolean] streaming_body A boolean value indicating if lazy row fetching is enabled
+  # @return [Boolean]
+  # @see Axlsx::lazy_row_fetching
+  def self.lazy_row_fetching=(lazy_row_fetching)
+    @lazy_row_fetching = lazy_row_fetching
+  end
+
 end

--- a/lib/axlsx/streaming/fake_io.rb
+++ b/lib/axlsx/streaming/fake_io.rb
@@ -1,0 +1,47 @@
+module Axlsx
+
+  module Streaming
+
+    class FakeIO
+
+      def initialize(&block)
+        @block = block
+        @pos = 0
+      end
+
+      def tell
+        @pos
+      end
+
+      def pos
+        @pos
+      end
+
+      def seek
+        throw :fit
+      end
+
+      def pos=
+        throw :fit
+      end
+
+      def to_s
+        throw :fit
+      end
+
+      def <<(x)
+        return if x.nil?
+        throw "bad class #{x.class}" unless x.class == String
+        @pos += x.bytesize
+        @block.call(x.to_s)
+      end
+
+      def close
+        nil
+      end
+
+    end
+
+  end
+
+end

--- a/lib/axlsx/streaming/output_stream.rb
+++ b/lib/axlsx/streaming/output_stream.rb
@@ -1,0 +1,48 @@
+require 'zip'
+
+module Axlsx
+
+  module Streaming
+
+    class OutputStream < Zip::OutputStream
+
+      class << self
+        def open(io)
+          zos = new(io)
+          yield zos
+        ensure
+          zos.close if zos
+        end
+      end
+
+      def initialize(io)
+        super io, true
+        @output_stream = io
+      end
+
+      def put_next_entry(zip_entry)
+        init_next_entry(zip_entry)
+        @current_entry = zip_entry
+      end
+
+      def finalize_current_entry
+        if @current_entry
+          entry = @current_entry
+          super
+          write_local_footer(entry)
+        end
+      end
+
+      def write_local_footer(entry)
+        @output_stream << [ 0x08074b50, entry.crc, entry.compressed_size, entry.size].pack('VVVV')
+      end
+
+      def update_local_headers
+        nil
+      end
+
+    end
+
+  end
+
+end

--- a/lib/axlsx/streaming/zip_body.rb
+++ b/lib/axlsx/streaming/zip_body.rb
@@ -1,0 +1,43 @@
+module Axlsx
+
+  module Streaming
+
+    class ZipBody
+
+      def initialize(parts, timestamp)
+        @parts = parts
+        @timestamp = timestamp
+      end
+
+      def each(&block)
+        OutputStream.open( FakeIO.new(&block) ) do |zip|
+          @parts.each do |part|
+            next if part[:doc].nil?
+            zip.put_next_entry(zip_entry_for_part(part))
+            entry = part[:doc]
+            case entry
+            when String
+              zip << entry
+            when Enumerator
+              entry.each { |line| zip << line }
+            end
+          end
+        end
+      end
+
+      private
+
+      def zip_entry_for_part(part)
+        timestamp = Zip::DOSTime.at(@timestamp)
+        zip_entry = Zip::Entry.new("", part[:entry], "", "", 0, 0, Zip::Entry::DEFLATED, 0, timestamp)
+        #THIS IS THE MAGIC, tells zip to look after data for size, crc
+        zip_entry.gp_flags |= 0x0008
+        zip_entry
+      end
+
+    end
+
+  end
+
+end
+

--- a/lib/axlsx/workbook/workbook.rb
+++ b/lib/axlsx/workbook/workbook.rb
@@ -37,6 +37,7 @@ require 'axlsx/workbook/worksheet/worksheet_hyperlinks'
 require 'axlsx/workbook/worksheet/break'
 require 'axlsx/workbook/worksheet/row_breaks'
 require 'axlsx/workbook/worksheet/col_breaks'
+require 'axlsx/workbook/worksheet/row_container'
 require 'axlsx/workbook/workbook_view'
 require 'axlsx/workbook/workbook_views'
 

--- a/lib/axlsx/workbook/worksheet/row_container.rb
+++ b/lib/axlsx/workbook/worksheet/row_container.rb
@@ -1,0 +1,58 @@
+module Axlsx
+
+  class RowContainer
+
+    def initialize(row_enumerator)
+      @row_enumerator = row_enumerator
+      @rows = SimpleTypedList.new Row
+    end
+
+    def each(&block)
+      rows = @row_enumerator ? @row_enumerator : @rows
+      rows.each(&block)
+    end
+
+    def each_with_index(&block)
+      rows = @row_enumerator ? @row_enumerator : @rows
+      rows.each_with_index(&block)
+    end
+
+    def index(row)
+      @rows.index(row)
+    end
+
+    def <<(row)
+      @rows << row
+    end
+
+    def [](index)
+      @rows[index]
+    end
+
+    def empty?
+      @rows.empty?
+    end
+
+    def first
+      @rows.first
+    end
+
+    def last
+      @rows.last
+    end
+
+    def size
+      @rows.size
+    end
+
+    def transpose(&block)
+      @rows.transpose(&block)
+    end
+
+    def flatten
+      @rows.flatten
+    end
+
+  end
+
+end

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -28,6 +28,7 @@ module Axlsx
       parse_options options
       @workbook.worksheets << self
       @sheet_id = index + 1
+      @row_enumerator = false
       yield self if block_given?
     end
 
@@ -148,7 +149,11 @@ module Axlsx
     # @return [SimpleTypedList]
     # @see Worksheet#add_row
     def rows
-      @rows ||=  SimpleTypedList.new Row
+      @rows ||= if Axlsx.lazy_row_fetching
+        RowContainer.new @row_enumerator
+      else
+        SimpleTypedList.new Row
+      end
     end
 
     # returns the sheet data as columns
@@ -455,6 +460,11 @@ module Axlsx
 
     alias :<< :add_row
 
+    # Allows you to pass in an enumerator that adds rows which will lazily fetch rows on render
+    def fetch_rows_with(enumerator)
+      @row_enumerator = enumerator
+    end
+
     # Add conditional formatting to this worksheet.
     #
     # @param [String] cells The range to apply the formatting to
@@ -608,15 +618,17 @@ module Axlsx
     # Serializes the worksheet object to an xml string
     # This intentionally does not use nokogiri for performance reasons
     # @return [String]
-    def to_xml_string
+    def to_xml_string(str='')
       auto_filter.apply if auto_filter.range
-      str = '<?xml version="1.0" encoding="UTF-8"?>'
+      str << '<?xml version="1.0" encoding="UTF-8"?>'
       str << worksheet_node
+      serialized_sheet_data
       serializable_parts.each do |item|
         item.to_xml_string(str) if item
       end
       str << '</worksheet>'
-      Axlsx::sanitize(str)
+      # Cannot sanitize if it is an Enumerator
+      Axlsx::sanitize(str) if str.class == String
     end
 
     # The worksheet relationships. This is managed automatically by the worksheet
@@ -767,6 +779,10 @@ module Axlsx
 
     def sheet_data
       @sheet_data ||= SheetData.new self
+    end
+
+    def serialized_sheet_data
+      @serialized_sheet_data ||= sheet_data.to_xml_string
     end
 
     def worksheet_drawing


### PR DESCRIPTION
This is a working proof of concept for producing a stream for saving or sending (e.g., from a web server) an xlsx document before it has completely rendered the entire document. This is useful for very large datasets where you would like to start the sending the file as soon as possible so that the user can start downloading it. I would like to know if the approach is something you would find acceptable, and if so, what revisions would be needed to have it accepted. Although it is fairly simple, I had to shoehorn the additional functionality into the gem. There may be a better way to achieve the same result, one which would apply not just to streaming the worksheet, but all the other xml documents as well. A limitation of the current code is that I had to disable validation for the worksheet. However, since the additional functionality has a feature flag, this limitation only applies when streaming. All the tests are passing. Any feedback would be appreciated. 
