### PR TITLE
Huge refactoring

### DIFF
--- a/lib/axlsx/content_type/abstract_content_type.rb
+++ b/lib/axlsx/content_type/abstract_content_type.rb
@@ -24,7 +24,7 @@ module Axlsx
     # Serialize the contenty type to xml
     def to_xml_string(node_name = '', str = '')
       str << "<#{node_name} "
-      str << instance_values.map { |key, value| '' << Axlsx::camel(key) << '="' << value.to_s << '"' }.join(' ')
+      str << instance_values.map { |key, value| Axlsx::camel(key) << '="' << value.to_s << '"' }.join(' ')
       str << '/>'
     end
 

--- a/lib/axlsx/content_type/content_type.rb
+++ b/lib/axlsx/content_type/content_type.rb
@@ -16,7 +16,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << '<Types xmlns="' << XML_NS_T << '">'
+      str << ('<Types xmlns="' << XML_NS_T << '">')
       each { |type| type.to_xml_string(str) }
       str << '</Types>'
     end

--- a/lib/axlsx/doc_props/app.rb
+++ b/lib/axlsx/doc_props/app.rb
@@ -222,7 +222,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << '<Properties xmlns="' << APP_NS << '" xmlns:vt="' << APP_NS_VT << '">'
+      str << ('<Properties xmlns="' << APP_NS << '" xmlns:vt="' << APP_NS_VT << '">')
       instance_values.each do |key, value|
         node_name = Axlsx.camel(key)
         str << "<#{node_name}>#{value}</#{node_name}>"

--- a/lib/axlsx/doc_props/core.rb
+++ b/lib/axlsx/doc_props/core.rb
@@ -25,11 +25,11 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << '<cp:coreProperties xmlns:cp="' << CORE_NS << '" xmlns:dc="' << CORE_NS_DC << '" '
-      str << 'xmlns:dcmitype="' << CORE_NS_DCMIT << '" xmlns:dcterms="' << CORE_NS_DCT << '" '
-      str << 'xmlns:xsi="' << CORE_NS_XSI << '">'
-      str << '<dc:creator>' << self.creator << '</dc:creator>'
-      str << '<dcterms:created xsi:type="dcterms:W3CDTF">' << (created || Time.now).strftime('%Y-%m-%dT%H:%M:%S') << 'Z</dcterms:created>'
+      str << ('<cp:coreProperties xmlns:cp="' << CORE_NS << '" xmlns:dc="' << CORE_NS_DC << '" ')
+      str << ('xmlns:dcmitype="' << CORE_NS_DCMIT << '" xmlns:dcterms="' << CORE_NS_DCT << '" ')
+      str << ('xmlns:xsi="' << CORE_NS_XSI << '">')
+      str << ('<dc:creator>' << self.creator << '</dc:creator>')
+      str << ('<dcterms:created xsi:type="dcterms:W3CDTF">' << (created || Time.now).strftime('%Y-%m-%dT%H:%M:%S') << 'Z</dcterms:created>')
       str << '<cp:revision>0</cp:revision>'
       str << '</cp:coreProperties>'
     end

--- a/lib/axlsx/drawing/axes.rb
+++ b/lib/axlsx/drawing/axes.rb
@@ -32,7 +32,7 @@ module Axlsx
       if options[:ids]
         # CatAxis must come first in the XML (for Microsoft Excel at least)
         sorted = axes.sort_by { |name, axis| axis.kind_of?(CatAxis) ? 0 : 1 }
-        sorted.inject(str) { |string, axis| string << '<c:axId val="' << axis[1].id.to_s << '"/>' }        
+        sorted.each { |axis| str << ('<c:axId val="' << axis[1].id.to_s << '"/>') }        
       else
         axes.each { |axis| axis[1].to_xml_string(str) }
       end

--- a/lib/axlsx/drawing/axis.rb
+++ b/lib/axlsx/drawing/axis.rb
@@ -150,10 +150,10 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<c:axId val="' << @id.to_s << '"/>'
+      str << ('<c:axId val="' << @id.to_s << '"/>')
       @scaling.to_xml_string str
-      str << '<c:delete val="'<< @delete.to_s << '"/>'
-      str << '<c:axPos val="' << @ax_pos.to_s << '"/>'
+      str << ('<c:delete val="' << @delete.to_s << '"/>')
+      str << ('<c:axPos val="' << @ax_pos.to_s << '"/>')
       str << '<c:majorGridlines>'
       # TODO shape properties need to be extracted into a class
       if gridlines == false
@@ -165,21 +165,21 @@ module Axlsx
       end
       str << '</c:majorGridlines>'
       @title.to_xml_string(str) unless @title == nil
-      str << '<c:numFmt formatCode="' << @format_code << '" sourceLinked="1"/>'
+      str << ('<c:numFmt formatCode="' << @format_code << '" sourceLinked="1"/>')
       str << '<c:majorTickMark val="none"/>'
       str << '<c:minorTickMark val="none"/>'
-      str << '<c:tickLblPos val="' << @tick_lbl_pos.to_s << '"/>'
+      str << ('<c:tickLblPos val="' << @tick_lbl_pos.to_s << '"/>')
       # TODO - this is also being used for series colors
       # time to extract this into a class spPr - Shape Properties
       if @color
         str << '<c:spPr><a:ln><a:solidFill>'
-        str << '<a:srgbClr val="' << @color << '"/>'
+        str << ('<a:srgbClr val="' << @color << '"/>')
         str << '</a:solidFill></a:ln></c:spPr>'
       end
       # some potential value in implementing this in full. Very detailed!
-      str << '<c:txPr><a:bodyPr rot="' << @label_rotation.to_s << '"/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:endParaRPr/></a:p></c:txPr>'
-      str << '<c:crossAx val="' << @cross_axis.id.to_s << '"/>'
-      str << '<c:crosses val="' << @crosses.to_s << '"/>'
+      str << ('<c:txPr><a:bodyPr rot="' << @label_rotation.to_s << '"/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:endParaRPr/></a:p></c:txPr>')
+      str << ('<c:crossAx val="' << @cross_axis.id.to_s << '"/>')
+      str << ('<c:crosses val="' << @crosses.to_s << '"/>')
     end
 
   end

--- a/lib/axlsx/drawing/bar_3D_chart.rb
+++ b/lib/axlsx/drawing/bar_3D_chart.rb
@@ -125,19 +125,19 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      super(str) do |str_inner|
-        str_inner << '<c:bar3DChart>'
-        str_inner << '<c:barDir val="' << bar_dir.to_s << '"/>'
-        str_inner << '<c:grouping val="' << grouping.to_s << '"/>'
-        str_inner << '<c:varyColors val="' << vary_colors.to_s << '"/>'
-        @series.each { |ser| ser.to_xml_string(str_inner) }
-        @d_lbls.to_xml_string(str_inner) if @d_lbls
-        str_inner << '<c:gapWidth val="' << @gap_width.to_s << '"/>' unless @gap_width.nil?
-        str_inner << '<c:gapDepth val="' << @gap_depth.to_s << '"/>' unless @gap_depth.nil?
-        str_inner << '<c:shape val="' << @shape.to_s << '"/>' unless @shape.nil?
-        axes.to_xml_string(str_inner, :ids => true)
-        str_inner << '</c:bar3DChart>'
-        axes.to_xml_string(str_inner)
+      super(str) do
+        str << '<c:bar3DChart>'
+        str << ('<c:barDir val="' << bar_dir.to_s << '"/>')
+        str << ('<c:grouping val="' << grouping.to_s << '"/>')
+        str << ('<c:varyColors val="' << vary_colors.to_s << '"/>')
+        @series.each { |ser| ser.to_xml_string(str) }
+        @d_lbls.to_xml_string(str) if @d_lbls
+        str << ('<c:gapWidth val="' << @gap_width.to_s << '"/>') unless @gap_width.nil?
+        str << ('<c:gapDepth val="' << @gap_depth.to_s << '"/>') unless @gap_depth.nil?
+        str << ('<c:shape val="' << @shape.to_s << '"/>') unless @shape.nil?
+        axes.to_xml_string(str, :ids => true)
+        str << '</c:bar3DChart>'
+        axes.to_xml_string(str)
       end
     end
 

--- a/lib/axlsx/drawing/bar_series.rb
+++ b/lib/axlsx/drawing/bar_series.rb
@@ -52,20 +52,20 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      super(str) do |str_inner|
+      super(str) do
 
         colors.each_with_index do |c, index|
-          str_inner << '<c:dPt>'
-          str_inner << '<c:idx val="' << index.to_s << '"/>'
-          str_inner << '<c:spPr><a:solidFill>'
-          str_inner << '<a:srgbClr val="' << c << '"/>'
-          str_inner << '</a:solidFill></c:spPr></c:dPt>'
+          str << '<c:dPt>'
+          str << ('<c:idx val="' << index.to_s << '"/>')
+          str << '<c:spPr><a:solidFill>'
+          str << ('<a:srgbClr val="' << c << '"/>')
+          str << '</a:solidFill></c:spPr></c:dPt>'
         end
 
-        @labels.to_xml_string(str_inner) unless @labels.nil?
-        @data.to_xml_string(str_inner) unless @data.nil?
+        @labels.to_xml_string(str) unless @labels.nil?
+        @data.to_xml_string(str) unless @data.nil?
         # this is actually only required for shapes other than box 
-        str_inner << '<c:shape val="' << shape.to_s << '"></c:shape>'
+        str << ('<c:shape val="' << shape.to_s << '"></c:shape>')
       end
     end
 

--- a/lib/axlsx/drawing/bubble_chart.rb
+++ b/lib/axlsx/drawing/bubble_chart.rb
@@ -37,14 +37,14 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      super(str) do |str_inner|
-        str_inner << '<c:bubbleChart>'
-        str_inner << '<c:varyColors val="' << vary_colors.to_s << '"/>'
-        @series.each { |ser| ser.to_xml_string(str_inner) }
-        d_lbls.to_xml_string(str_inner) if @d_lbls
-        axes.to_xml_string(str_inner, :ids => true)
-        str_inner << '</c:bubbleChart>'
-        axes.to_xml_string(str_inner)
+      super(str) do
+        str << '<c:bubbleChart>'
+        str << ('<c:varyColors val="' << vary_colors.to_s << '"/>')
+        @series.each { |ser| ser.to_xml_string(str) }
+        d_lbls.to_xml_string(str) if @d_lbls
+        axes.to_xml_string(str, :ids => true)
+        str << '</c:bubbleChart>'
+        axes.to_xml_string(str)
       end
       str
     end

--- a/lib/axlsx/drawing/bubble_series.rb
+++ b/lib/axlsx/drawing/bubble_series.rb
@@ -43,19 +43,19 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      super(str) do |inner_str|
+      super(str) do
         # needs to override the super color here to push in ln/and something else!
         if color
           str << '<c:spPr><a:solidFill>'
-          str << '<a:srgbClr val="' << color << '"/>'
+          str << ('<a:srgbClr val="' << color << '"/>')
           str << '</a:solidFill>'
           str << '<a:ln><a:solidFill>'
-          str << '<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>'
+          str << ('<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>')
           str << '</c:spPr>'
         end
-        @xData.to_xml_string(inner_str) unless @xData.nil?
-        @yData.to_xml_string(inner_str) unless @yData.nil?
-        @bubbleSize.to_xml_string(inner_str) unless @bubbleSize.nil?
+        @xData.to_xml_string(str) unless @xData.nil?
+        @yData.to_xml_string(str) unless @yData.nil?
+        @bubbleSize.to_xml_string(str) unless @bubbleSize.nil?
       end
       str
     end

--- a/lib/axlsx/drawing/cat_axis.rb
+++ b/lib/axlsx/drawing/cat_axis.rb
@@ -71,11 +71,11 @@ module Axlsx
     def to_xml_string(str = '')
       str << '<c:catAx>'
       super(str)
-      str << '<c:auto val="' << @auto.to_s << '"/>'
-      str << '<c:lblAlgn val="' << @lbl_algn.to_s << '"/>'
-      str << '<c:lblOffset val="' << @lbl_offset.to_i.to_s << '"/>'
-      str << '<c:tickLblSkip val="' << @tick_lbl_skip.to_s << '"/>'
-      str << '<c:tickMarkSkip val="' << @tick_mark_skip.to_s << '"/>'
+      str << ('<c:auto val="' << @auto.to_s << '"/>')
+      str << ('<c:lblAlgn val="' << @lbl_algn.to_s << '"/>')
+      str << ('<c:lblOffset val="' << @lbl_offset.to_i.to_s << '"/>')
+      str << ('<c:tickLblSkip val="' << @tick_lbl_skip.to_s << '"/>')
+      str << ('<c:tickMarkSkip val="' << @tick_mark_skip.to_s << '"/>')
       str << '</c:catAx>'
     end
 

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -151,19 +151,19 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << '<c:chartSpace xmlns:c="' << XML_NS_C << '" xmlns:a="' << XML_NS_A << '" xmlns:r="' << XML_NS_R << '">'
-      str << '<c:date1904 val="' << Axlsx::Workbook.date1904.to_s << '"/>'
-      str << '<c:style val="' << style.to_s << '"/>'
+      str << ('<c:chartSpace xmlns:c="' << XML_NS_C << '" xmlns:a="' << XML_NS_A << '" xmlns:r="' << XML_NS_R << '">')
+      str << ('<c:date1904 val="' << Axlsx::Workbook.date1904.to_s << '"/>')
+      str << ('<c:style val="' << style.to_s << '"/>')
       str << '<c:chart>'
       @title.to_xml_string str
-      str << '<c:autoTitleDeleted val="' << (@title == nil).to_s << '"/>'
+      str << ('<c:autoTitleDeleted val="' << (@title == nil).to_s << '"/>')
       @view_3D.to_xml_string(str) if @view_3D
       str << '<c:floor><c:thickness val="0"/></c:floor>'
       str << '<c:sideWall><c:thickness val="0"/></c:sideWall>'
       str << '<c:backWall><c:thickness val="0"/></c:backWall>'
       str << '<c:plotArea>'
       str << '<c:layout/>'
-      yield str if block_given?
+      yield if block_given?
       str << '</c:plotArea>'
       if @show_legend
         str << '<c:legend>'
@@ -173,7 +173,7 @@ module Axlsx
         str << '</c:legend>'
       end
       str << '<c:plotVisOnly val="1"/>'
-      str << '<c:dispBlanksAs val="' << display_blanks_as.to_s << '"/>'
+      str << ('<c:dispBlanksAs val="' << display_blanks_as.to_s << '"/>')
       str << '<c:showDLblsOverMax val="1"/>'
       str << '</c:chart>'
       str << '<c:printSettings>'

--- a/lib/axlsx/drawing/drawing.rb
+++ b/lib/axlsx/drawing/drawing.rb
@@ -155,7 +155,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       str << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-      str << '<xdr:wsDr xmlns:xdr="' << XML_NS_XDR << '" xmlns:a="' << XML_NS_A << '">'
+      str << ('<xdr:wsDr xmlns:xdr="' << XML_NS_XDR << '" xmlns:a="' << XML_NS_A << '">')
       anchors.each { |anchor| anchor.to_xml_string(str) }
       str << '</xdr:wsDr>'
     end

--- a/lib/axlsx/drawing/graphic_frame.rb
+++ b/lib/axlsx/drawing/graphic_frame.rb
@@ -35,7 +35,7 @@ module Axlsx
       # macro attribute should be optional!
       str << '<xdr:graphicFrame>'
       str << '<xdr:nvGraphicFramePr>'
-      str << '<xdr:cNvPr id="' << @anchor.drawing.index.to_s << '" name="' << 'item_' << @anchor.drawing.index.to_s << '"/>'
+      str << ('<xdr:cNvPr id="' << @anchor.drawing.index.to_s << '" name="' << 'item_' << @anchor.drawing.index.to_s << '"/>')
       str << '<xdr:cNvGraphicFramePr/>'
       str << '</xdr:nvGraphicFramePr>'
       str << '<xdr:xfrm>'
@@ -43,8 +43,8 @@ module Axlsx
       str << '<a:ext cx="0" cy="0"/>'
       str << '</xdr:xfrm>'
       str << '<a:graphic>'
-      str << '<a:graphicData uri="' << XML_NS_C << '">'
-      str << '<c:chart xmlns:c="' << XML_NS_C << '" xmlns:r="' << XML_NS_R << '" r:id="' << rId << '"/>'
+      str << ('<a:graphicData uri="' << XML_NS_C << '">')
+      str << ('<c:chart xmlns:c="' << XML_NS_C << '" xmlns:r="' << XML_NS_R << '" r:id="' << rId << '"/>')
       str << '</a:graphicData>'
       str << '</a:graphic>'
       str << '</xdr:graphicFrame>'

--- a/lib/axlsx/drawing/hyperlink.rb
+++ b/lib/axlsx/drawing/hyperlink.rb
@@ -93,9 +93,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<a:hlinkClick '
-      serialized_attributes str, {:'r:id' => relationship.Id, :'xmlns:r' => XML_NS_R }
-      str << '/>'
+      serialized_tag 'a:hlinkClick', str, {:'r:id' => relationship.Id, :'xmlns:r' => XML_NS_R }
     end
 
   end

--- a/lib/axlsx/drawing/line_3D_chart.rb
+++ b/lib/axlsx/drawing/line_3D_chart.rb
@@ -60,8 +60,8 @@ module Axlsx
       # @param [String] str
       # @return [String]
       def to_xml_string(str = '')
-        super(str) do |str_inner|
-          str_inner << '<c:gapDepth val="' << @gap_depth.to_s << '"/>' unless @gap_depth.nil?
+        super(str) do
+          str << ('<c:gapDepth val="' << @gap_depth.to_s << '"/>') unless @gap_depth.nil?
         end
       end
   end

--- a/lib/axlsx/drawing/line_chart.rb
+++ b/lib/axlsx/drawing/line_chart.rb
@@ -76,16 +76,16 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      super(str) do |str_inner|
-        str_inner << "<c:" << node_name << ">"
-        str_inner << '<c:grouping val="' << grouping.to_s << '"/>'
-        str_inner << '<c:varyColors val="' << vary_colors.to_s << '"/>'
-        @series.each { |ser| ser.to_xml_string(str_inner) }
-        @d_lbls.to_xml_string(str_inner) if @d_lbls
-        yield str_inner if block_given?
-        axes.to_xml_string(str_inner, :ids => true)
-        str_inner << "</c:" << node_name << ">"
-        axes.to_xml_string(str_inner)
+      super(str) do
+        str << ("<c:" << node_name << ">")
+        str << ('<c:grouping val="' << grouping.to_s << '"/>')
+        str << ('<c:varyColors val="' << vary_colors.to_s << '"/>')
+        @series.each { |ser| ser.to_xml_string(str) }
+        @d_lbls.to_xml_string(str) if @d_lbls
+        yield if block_given?
+        axes.to_xml_string(str, :ids => true)
+        str << ("</c:" << node_name << ">")
+        axes.to_xml_string(str)
       end
     end
 

--- a/lib/axlsx/drawing/line_series.rb
+++ b/lib/axlsx/drawing/line_series.rb
@@ -64,11 +64,11 @@ module Axlsx
       super(str) do
         if color
           str << '<c:spPr><a:solidFill>'
-          str << '<a:srgbClr val="' << color << '"/>'
+          str << ('<a:srgbClr val="' << color << '"/>')
           str << '</a:solidFill>'
           str << '<a:ln w="28800">'
           str << '<a:solidFill>'
-          str << '<a:srgbClr val="' << color << '"/>'
+          str << ('<a:srgbClr val="' << color << '"/>')
           str << '</a:solidFill>'
           str << '</a:ln>'
           str << '<a:round/>'
@@ -77,7 +77,7 @@ module Axlsx
         str << '<c:marker><c:symbol val="none"/></c:marker>' unless @show_marker
         @labels.to_xml_string(str) unless @labels.nil?
         @data.to_xml_string(str) unless @data.nil?
-        str << '<c:smooth val="' << ((smooth) ? '1' : '0') << '"/>'
+        str << ('<c:smooth val="' << ((smooth) ? '1' : '0') << '"/>')
       end
     end
 

--- a/lib/axlsx/drawing/marker.rb
+++ b/lib/axlsx/drawing/marker.rb
@@ -58,7 +58,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       [:col, :colOff, :row, :rowOff].each do |k|
-        str << '<xdr:' << k.to_s << '>' << self.send(k).to_s << '</xdr:' << k.to_s << '>'
+        str << ('<xdr:' << k.to_s << '>' << self.send(k).to_s << '</xdr:' << k.to_s << '>')
       end
     end
     private

--- a/lib/axlsx/drawing/num_data.rb
+++ b/lib/axlsx/drawing/num_data.rb
@@ -38,13 +38,13 @@ module Axlsx
 
     # serialize the object
     def to_xml_string(str = "")
-      str << '<c:' << @tag_name.to_s << '>'
-      str << '<c:formatCode>' << format_code.to_s << '</c:formatCode>'
-      str << '<c:ptCount val="' << @pt.size.to_s << '"/>'
+      str << ('<c:' << @tag_name.to_s << '>')
+      str << ('<c:formatCode>' << format_code.to_s << '</c:formatCode>')
+      str << ('<c:ptCount val="' << @pt.size.to_s << '"/>')
       @pt.each_with_index do |num_val, index|
         num_val.to_xml_string index, str
       end
-      str << '</c:' << @tag_name.to_s << '>'
+      str << ('</c:' << @tag_name.to_s << '>')
     end
 
   end

--- a/lib/axlsx/drawing/num_data_source.rb
+++ b/lib/axlsx/drawing/num_data_source.rb
@@ -46,16 +46,16 @@ module Axlsx
     # serialize the object
     # @param [String] str
     def to_xml_string(str="")
-      str << '<c:' << tag_name.to_s << '>'
+      str << ('<c:' << tag_name.to_s << '>')
       if @f
-        str << '<c:' << @ref_tag_name.to_s << '>'
-        str << '<c:f>' << @f.to_s << '</c:f>'
+        str << ('<c:' << @ref_tag_name.to_s << '>')
+        str << ('<c:f>' << @f.to_s << '</c:f>')
       end
       @data.to_xml_string str
       if @f
-        str << '</c:' << @ref_tag_name.to_s << '>'
+        str << ('</c:' << @ref_tag_name.to_s << '>')
       end
-      str << '</c:' << tag_name.to_s << '>'
+      str << ('</c:' << tag_name.to_s << '>')
     end
   end
 end

--- a/lib/axlsx/drawing/num_val.rb
+++ b/lib/axlsx/drawing/num_val.rb
@@ -26,7 +26,7 @@ module Axlsx
     # serialize the object
     def to_xml_string(idx, str = "")
       Axlsx::validate_unsigned_int(idx)
-      str << '<c:pt idx="' << idx.to_s << '" formatCode="' << format_code << '"><c:v>' << v.to_s << '</c:v></c:pt>'
+      str << ('<c:pt idx="' << idx.to_s << '" formatCode="' << format_code << '"><c:v>' << v.to_s << '</c:v></c:pt>')
     end
   end
 end

--- a/lib/axlsx/drawing/one_cell_anchor.rb
+++ b/lib/axlsx/drawing/one_cell_anchor.rb
@@ -77,7 +77,7 @@ module Axlsx
       str << '<xdr:from>'
       from.to_xml_string(str)
       str << '</xdr:from>'
-      str << '<xdr:ext cx="' << ext[:cx].to_s << '" cy="' << ext[:cy].to_s << '"/>'
+      str << ('<xdr:ext cx="' << ext[:cx].to_s << '" cy="' << ext[:cy].to_s << '"/>')
       @object.to_xml_string(str)
       str << '<xdr:clientData/>'
       str << '</xdr:oneCellAnchor>'

--- a/lib/axlsx/drawing/pic.rb
+++ b/lib/axlsx/drawing/pic.rb
@@ -165,17 +165,16 @@ module Axlsx
     def to_xml_string(str = '')
       str << '<xdr:pic>'
       str << '<xdr:nvPicPr>'
-      str << '<xdr:cNvPr id="2" name="' << name.to_s << '" descr="' << descr.to_s << '">'
+      str << ('<xdr:cNvPr id="2" name="' << name.to_s << '" descr="' << descr.to_s << '">')
       @hyperlink.to_xml_string(str) if @hyperlink.is_a?(Hyperlink)
       str << '</xdr:cNvPr><xdr:cNvPicPr>'
       picture_locking.to_xml_string(str)
       str << '</xdr:cNvPicPr></xdr:nvPicPr>'
       str << '<xdr:blipFill>'
-      str << '<a:blip xmlns:r ="' << XML_NS_R << '" r:embed="' << relationship.Id <<  '"/>'
+      str << ('<a:blip xmlns:r ="' << XML_NS_R << '" r:embed="' << relationship.Id << '"/>')
       str << '<a:stretch><a:fillRect/></a:stretch></xdr:blipFill><xdr:spPr>'
       str << '<a:xfrm><a:off x="0" y="0"/><a:ext cx="2336800" cy="2161540"/></a:xfrm>'
       str << '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></xdr:spPr></xdr:pic>'
-
     end
 
     private

--- a/lib/axlsx/drawing/picture_locking.rb
+++ b/lib/axlsx/drawing/picture_locking.rb
@@ -35,9 +35,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<a:picLocks '
-      serialized_attributes str
-      str << '/>'
+      serialized_tag('a:picLocks', str)
     end
 
   end

--- a/lib/axlsx/drawing/pie_3D_chart.rb
+++ b/lib/axlsx/drawing/pie_3D_chart.rb
@@ -34,13 +34,12 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      super(str) do |str_inner|
-
-        str_inner << '<c:pie3DChart>'
-        str_inner << '<c:varyColors val="' << vary_colors.to_s << '"/>'
-        @series.each { |ser| ser.to_xml_string(str_inner) }
+      super(str) do
+        str << '<c:pie3DChart>'
+        str << ('<c:varyColors val="' << vary_colors.to_s << '"/>')
+        @series.each { |ser| ser.to_xml_string(str) }
         d_lbls.to_xml_string(str) if @d_lbls
-        str_inner << '</c:pie3DChart>'
+        str << '</c:pie3DChart>'
       end
     end
 

--- a/lib/axlsx/drawing/pie_series.rb
+++ b/lib/axlsx/drawing/pie_series.rb
@@ -46,17 +46,17 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      super(str) do |str_inner|
-        str_inner << '<c:explosion val="' << @explosion << '"/>' unless @explosion.nil?
+      super(str) do
+        str << '<c:explosion val="' + @explosion + '"/>' unless @explosion.nil?
         colors.each_with_index do |c, index|
           str << '<c:dPt>'
-          str << '<c:idx val="' << index.to_s << '"/>'
+          str << ('<c:idx val="' << index.to_s << '"/>')
           str << '<c:spPr><a:solidFill>'
-          str << '<a:srgbClr val="' << c << '"/>'
+          str << ('<a:srgbClr val="' << c << '"/>')
           str << '</a:solidFill></c:spPr></c:dPt>'
         end
-        @labels.to_xml_string str_inner unless @labels.nil?
-        @data.to_xml_string str_inner unless @data.nil?
+        @labels.to_xml_string str unless @labels.nil?
+        @data.to_xml_string str unless @data.nil?
       end
       str
     end

--- a/lib/axlsx/drawing/scaling.rb
+++ b/lib/axlsx/drawing/scaling.rb
@@ -49,10 +49,10 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       str << '<c:scaling>'
-      str << '<c:logBase val="' << @logBase.to_s << '"/>' unless @logBase.nil?
-      str << '<c:orientation val="' << @orientation.to_s << '"/>' unless @orientation.nil?
-      str << '<c:min val="' << @min.to_s << '"/>' unless @min.nil?
-      str << '<c:max val="' << @max.to_s << '"/>' unless @max.nil?
+      str << ('<c:logBase val="' << @logBase.to_s << '"/>') unless @logBase.nil?
+      str << ('<c:orientation val="' << @orientation.to_s << '"/>') unless @orientation.nil?
+      str << ('<c:min val="' << @min.to_s << '"/>') unless @min.nil?
+      str << ('<c:max val="' << @max.to_s << '"/>') unless @max.nil?
       str << '</c:scaling>'
     end
 

--- a/lib/axlsx/drawing/scatter_chart.rb
+++ b/lib/axlsx/drawing/scatter_chart.rb
@@ -51,15 +51,15 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      super(str) do |str_inner|
-        str_inner << '<c:scatterChart>'
-        str_inner << '<c:scatterStyle val="' << scatter_style.to_s << '"/>'
-        str_inner << '<c:varyColors val="' << vary_colors.to_s << '"/>'
-        @series.each { |ser| ser.to_xml_string(str_inner) }
-        d_lbls.to_xml_string(str_inner) if @d_lbls
-        axes.to_xml_string(str_inner, :ids => true)
-        str_inner << '</c:scatterChart>'
-        axes.to_xml_string(str_inner)
+      super(str) do
+        str << '<c:scatterChart>'
+        str << ('<c:scatterStyle val="' << scatter_style.to_s << '"/>')
+        str << ('<c:varyColors val="' << vary_colors.to_s << '"/>')
+        @series.each { |ser| ser.to_xml_string(str) }
+        d_lbls.to_xml_string(str) if @d_lbls
+        axes.to_xml_string(str, :ids => true)
+        str << '</c:scatterChart>'
+        axes.to_xml_string(str)
       end
       str
     end

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -38,26 +38,26 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      super(str) do |inner_str|
+      super(str) do
         # needs to override the super color here to push in ln/and something else!
         if color
           str << '<c:spPr><a:solidFill>'
-          str << '<a:srgbClr val="' << color << '"/>'
+          str << ('<a:srgbClr val="' << color << '"/>')
           str << '</a:solidFill>'
           str << '<a:ln><a:solidFill>'
-          str << '<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>'
+          str << ('<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>')
           str << '</c:spPr>'
           str << '<c:marker>'
           str << '<c:spPr><a:solidFill>'
-          str << '<a:srgbClr val="' << color << '"/>'
+          str << ('<a:srgbClr val="' << color << '"/>')
           str << '</a:solidFill>'
           str << '<a:ln><a:solidFill>'
-          str << '<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>'
+          str << ('<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>')
           str << '</c:spPr>'
           str << '</c:marker>'
         end
-        @xData.to_xml_string(inner_str) unless @xData.nil?
-        @yData.to_xml_string(inner_str) unless @yData.nil?
+        @xData.to_xml_string(str) unless @xData.nil?
+        @yData.to_xml_string(str) unless @yData.nil?
       end
       str
     end

--- a/lib/axlsx/drawing/ser_axis.rb
+++ b/lib/axlsx/drawing/ser_axis.rb
@@ -35,8 +35,8 @@ module Axlsx
     def to_xml_string(str = '')
       str << '<c:serAx>'
       super(str)
-      str << '<c:tickLblSkip val="' << @tick_lbl_skip.to_s << '"/>' unless @tick_lbl_skip.nil?
-      str << '<c:tickMarkSkip val="' << @tick_mark_skip.to_s << '"/>' unless @tick_mark_skip.nil?
+      str << ('<c:tickLblSkip val="' << @tick_lbl_skip.to_s << '"/>') unless @tick_lbl_skip.nil?
+      str << ('<c:tickMarkSkip val="' << @tick_mark_skip.to_s << '"/>') unless @tick_mark_skip.nil?
       str << '</c:serAx>'
     end
   end

--- a/lib/axlsx/drawing/series.rb
+++ b/lib/axlsx/drawing/series.rb
@@ -59,10 +59,10 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       str << '<c:ser>'
-      str << '<c:idx val="' << index.to_s << '"/>'
-      str << '<c:order val="' << (order || index).to_s << '"/>'
+      str << ('<c:idx val="' << index.to_s << '"/>')
+      str << ('<c:order val="' << (order || index).to_s << '"/>')
       title.to_xml_string(str) unless title.nil?
-      yield str if block_given?
+      yield if block_given?
       str << '</c:ser>'
     end
   end

--- a/lib/axlsx/drawing/series_title.rb
+++ b/lib/axlsx/drawing/series_title.rb
@@ -9,11 +9,11 @@ module Axlsx
     def to_xml_string(str = '')
       str << '<c:tx>'
       str << '<c:strRef>'
-      str << '<c:f>' << Axlsx::cell_range([@cell]) << '</c:f>'
+      str << ('<c:f>' << Axlsx::cell_range([@cell]) << '</c:f>')
       str << '<c:strCache>'
       str << '<c:ptCount val="1"/>'
       str << '<c:pt idx="0">'
-      str << '<c:v>' << @text << '</c:v>'
+      str << ('<c:v>' << @text << '</c:v>')
       str << '</c:pt>'
       str << '</c:strCache>'
       str << '</c:strRef>'

--- a/lib/axlsx/drawing/str_data.rb
+++ b/lib/axlsx/drawing/str_data.rb
@@ -29,12 +29,12 @@ module Axlsx
 
     # serialize the object
     def to_xml_string(str = "")
-      str << '<c:' << @tag_name.to_s << '>'
-      str << '<c:ptCount val="' << @pt.size.to_s << '"/>'
+      str << ('<c:' << @tag_name.to_s << '>')
+      str << ('<c:ptCount val="' << @pt.size.to_s << '"/>')
       @pt.each_with_index do |value, index|
         value.to_xml_string index, str
       end
-      str << '</c:' << @tag_name.to_s << '>'
+      str << ('</c:' << @tag_name.to_s << '>')
     end
 
   end

--- a/lib/axlsx/drawing/str_val.rb
+++ b/lib/axlsx/drawing/str_val.rb
@@ -26,7 +26,7 @@ module Axlsx
     # serialize the object
     def to_xml_string(idx, str = "")
       Axlsx::validate_unsigned_int(idx)
-      str << '<c:pt idx="' << idx.to_s << '"><c:v>' << v.to_s << '</c:v></c:pt>'
+      str << ('<c:pt idx="' << idx.to_s << '"><c:v>' << v.to_s << '</c:v></c:pt>')
     end
   end
 end

--- a/lib/axlsx/drawing/title.rb
+++ b/lib/axlsx/drawing/title.rb
@@ -48,11 +48,11 @@ module Axlsx
         str << '<c:tx>'
         if @cell.is_a?(Cell)
           str << '<c:strRef>'
-          str << '<c:f>' << Axlsx::cell_range([@cell]) << '</c:f>'
+          str << ('<c:f>' << Axlsx::cell_range([@cell]) << '</c:f>')
           str << '<c:strCache>'
           str << '<c:ptCount val="1"/>'
           str << '<c:pt idx="0">'
-          str << '<c:v>' << @text << '</c:v>'
+          str << ('<c:v>' << @text << '</c:v>')
           str << '</c:pt>'
           str << '</c:strCache>'
           str << '</c:strRef>'
@@ -62,7 +62,7 @@ module Axlsx
             str << '<a:lstStyle/>'
             str << '<a:p>'
               str << '<a:r>'
-                str << '<a:t>' << @text.to_s << '</a:t>'
+                str << ('<a:t>' << @text.to_s << '</a:t>')
               str << '</a:r>'
             str << '</a:p>'
           str << '</c:rich>'

--- a/lib/axlsx/drawing/val_axis.rb
+++ b/lib/axlsx/drawing/val_axis.rb
@@ -29,7 +29,7 @@ module Axlsx
     def to_xml_string(str = '')
       str << '<c:valAx>'
       super(str)
-      str << '<c:crossBetween val="' << @cross_between.to_s << '"/>'
+      str << ('<c:crossBetween val="' << @cross_between.to_s << '"/>')
       str << '</c:valAx>'
     end
 

--- a/lib/axlsx/drawing/vml_drawing.rb
+++ b/lib/axlsx/drawing/vml_drawing.rb
@@ -20,7 +20,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str = <<BAD_PROGRAMMER
+      str << <<BAD_PROGRAMMER
 <xml xmlns:v="urn:schemas-microsoft-com:vml"
  xmlns:o="urn:schemas-microsoft-com:office:office"
  xmlns:x="urn:schemas-microsoft-com:office:excel">

--- a/lib/axlsx/rels/relationship.rb
+++ b/lib/axlsx/rels/relationship.rb
@@ -102,7 +102,7 @@ module Axlsx
     def to_xml_string(str = '')
       h = self.instance_values.reject{|k, _| k == "source_obj"}
       str << '<Relationship '
-      str << h.map { |key, value| '' << key.to_s << '="' << Axlsx::coder.encode(value.to_s) << '"'}.join(' ')
+      str << (h.map { |key, value| '' << key.to_s << '="' << Axlsx::coder.encode(value.to_s) << '"'}.join(' '))
       str << '/>'
     end
     

--- a/lib/axlsx/rels/relationships.rb
+++ b/lib/axlsx/rels/relationships.rb
@@ -15,12 +15,12 @@ require 'axlsx/rels/relationship.rb'
     # @see Relationship#source_obj
     # @return [Relationship]
     def for(source_obj)
-      @list.find{ |rel| rel.source_obj == source_obj }
+      find{ |rel| rel.source_obj == source_obj }
     end
     
     def to_xml_string(str = '')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << '<Relationships xmlns="' << RELS_R << '">'
+      str << ('<Relationships xmlns="' << RELS_R << '">')
       each{ |rel| rel.to_xml_string(str) }
       str << '</Relationships>'
     end

--- a/lib/axlsx/stylesheet/border_pr.rb
+++ b/lib/axlsx/stylesheet/border_pr.rb
@@ -62,9 +62,9 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<' << @name.to_s << ' style="' << @style.to_s << '">'
+      str << ('<' << @name.to_s << ' style="' << @style.to_s << '">')
       @color.to_xml_string(str) if @color.is_a?(Color)
-      str << '</' << @name.to_s << '>'
+      str << ('</' << @name.to_s << '>')
     end
 
   end

--- a/lib/axlsx/stylesheet/cell_alignment.rb
+++ b/lib/axlsx/stylesheet/cell_alignment.rb
@@ -125,9 +125,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<alignment '
-      serialized_attributes str
-      str << '/>'
+      serialized_tag('alignment', str)
     end
 
   end

--- a/lib/axlsx/stylesheet/cell_protection.rb
+++ b/lib/axlsx/stylesheet/cell_protection.rb
@@ -34,9 +34,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<protection '
-      serialized_attributes str
-      str << '/>'
+      serialized_tag('protection', str)
     end
 
   end

--- a/lib/axlsx/stylesheet/cell_style.rb
+++ b/lib/axlsx/stylesheet/cell_style.rb
@@ -64,9 +64,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<cellStyle '
-      serialized_attributes str
-      str << '/>'
+      serialized_tag('cellStyle', str)
     end
 
   end

--- a/lib/axlsx/stylesheet/color.rb
+++ b/lib/axlsx/stylesheet/color.rb
@@ -70,9 +70,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '', tag_name = 'color')
-      str << "<" << tag_name << " "
-      serialized_attributes str
-      str << "/>"
+      serialized_tag('' + tag_name + '', str)
     end
   end
 end

--- a/lib/axlsx/stylesheet/font.rb
+++ b/lib/axlsx/stylesheet/font.rb
@@ -140,7 +140,7 @@ module Axlsx
     def to_xml_string(str = '')
       str << '<font>'
       instance_values.each do |k, v|
-        v.is_a?(Color) ? v.to_xml_string(str) : (str << '<' << k.to_s << ' val="' << v.to_s << '"/>')
+        v.is_a?(Color) ? v.to_xml_string(str) : (str << ('<' << k.to_s << ' val="' << v.to_s << '"/>'))
       end
       str << '</font>'
     end

--- a/lib/axlsx/stylesheet/gradient_stop.rb
+++ b/lib/axlsx/stylesheet/gradient_stop.rb
@@ -29,7 +29,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<stop position="' << position.to_s << '">'
+      str << ('<stop position="' << position.to_s << '">')
       self.color.to_xml_string(str)
       str << '</stop>'
     end

--- a/lib/axlsx/stylesheet/num_fmt.rb
+++ b/lib/axlsx/stylesheet/num_fmt.rb
@@ -70,9 +70,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<numFmt '
-      serialized_attributes str
-      str << '/>'
+      serialized_tag('numFmt', str)
     end
 
   end

--- a/lib/axlsx/stylesheet/pattern_fill.rb
+++ b/lib/axlsx/stylesheet/pattern_fill.rb
@@ -59,7 +59,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<patternFill patternType="' << patternType.to_s << '">'
+      str << ('<patternFill patternType="' << patternType.to_s << '">')
       if fgColor.is_a?(Color)
         fgColor.to_xml_string str, "fgColor"
       end

--- a/lib/axlsx/stylesheet/styles.rb
+++ b/lib/axlsx/stylesheet/styles.rb
@@ -362,7 +362,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<styleSheet xmlns="' << XML_NS << '">'
+      str << ('<styleSheet xmlns="' << XML_NS << '">')
       [:numFmts, :fonts, :fills, :borders, :cellStyleXfs, :cellXfs, :cellStyles, :dxfs, :tableStyles].each do |key|
         self.instance_values[key.to_s].to_xml_string(str) unless self.instance_values[key.to_s].nil?
       end

--- a/lib/axlsx/stylesheet/table_style_element.rb
+++ b/lib/axlsx/stylesheet/table_style_element.rb
@@ -70,9 +70,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<tableStyleElement '
-      serialized_attributes str
-      str << '/>'
+      serialized_tag('tableStyleElement', str)
     end
 
   end

--- a/lib/axlsx/util/accessors.rb
+++ b/lib/axlsx/util/accessors.rb
@@ -19,7 +19,7 @@ module Axlsx
       # @param [Array] symbols An array of symbols representing the
       # names of the attributes you will add to your class.
       def string_attr_accessor(*symbols)
-        validated_attr_accessor(symbols, 'validate_string')
+        validated_attr_accessor(symbols, :validate_string)
       end
 
 
@@ -27,25 +27,25 @@ module Axlsx
       # @param [Array] symbols An array of symbols representing the
       # names of the attributes you will add to your class
       def unsigned_int_attr_accessor(*symbols)
-        validated_attr_accessor(symbols, 'validate_unsigned_int')
+        validated_attr_accessor(symbols, :validate_unsigned_int)
       end
 
       # Creates one or more float (double?) attr_accessors
       # @param [Array] symbols An array of symbols representing the
       # names of the attributes you will add to your class
       def float_attr_accessor(*symbols)
-        validated_attr_accessor(symbols, 'validate_float')
+        validated_attr_accessor(symbols, :validate_float)
       end
 
       # Creates on or more boolean validated attr_accessors
       # @param [Array] symbols An array of symbols representing the
       # names of the attributes you will add to your class.
       def boolean_attr_accessor(*symbols)
-        validated_attr_accessor(symbols, 'validate_boolean')
+        validated_attr_accessor(symbols, :validate_boolean)
       end
 
       # Template for defining validated write accessors
-      SETTER = "def %s=(value) Axlsx::%s(value); @%s = value; end"
+      SETTER = "def %s=(value) Axlsx::%s(value); @%s = value; end".freeze
 
       # Creates the reader and writer access methods
       # @param [Array] symbols The names of the attributes to create
@@ -55,7 +55,7 @@ module Axlsx
       def validated_attr_accessor(symbols, validator)
         symbols.each do |symbol|
           attr_reader symbol
-          module_eval(SETTER % [symbol.to_s, validator, symbol.to_s], __FILE__, __LINE__)
+          module_eval(SETTER % [symbol, validator, symbol], __FILE__, __LINE__)
         end
       end
     end

--- a/lib/axlsx/util/constants.rb
+++ b/lib/axlsx/util/constants.rb
@@ -1,263 +1,263 @@
 module Axlsx
 
   # XML Encoding
-  ENCODING = "UTF-8"
+  ENCODING = "UTF-8".freeze
 
   # spreadsheetML namespace
-  XML_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+  XML_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main".freeze
 
   # content-types namespace
-  XML_NS_T = "http://schemas.openxmlformats.org/package/2006/content-types"
+  XML_NS_T = "http://schemas.openxmlformats.org/package/2006/content-types".freeze
 
   # extended-properties namespace
-  APP_NS = "http://schemas.openxmlformats.org/officeDocument/2006/extended-properties"
+  APP_NS = "http://schemas.openxmlformats.org/officeDocument/2006/extended-properties".freeze
 
   # doc props namespace
-  APP_NS_VT = "http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"
+  APP_NS_VT = "http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes".freeze
 
   # core properties namespace
-  CORE_NS = "http://schemas.openxmlformats.org/package/2006/metadata/core-properties"
+  CORE_NS = "http://schemas.openxmlformats.org/package/2006/metadata/core-properties".freeze
 
   # dc elements (core) namespace
-  CORE_NS_DC = "http://purl.org/dc/elements/1.1/"
+  CORE_NS_DC = "http://purl.org/dc/elements/1.1/".freeze
 
   # dcmit (core) namespcace
-  CORE_NS_DCMIT = "http://purl.org/dc/dcmitype/"
+  CORE_NS_DCMIT = "http://purl.org/dc/dcmitype/".freeze
 
   # dc terms namespace
-  CORE_NS_DCT = "http://purl.org/dc/terms/"
+  CORE_NS_DCT = "http://purl.org/dc/terms/".freeze
 
   # xml schema namespace
-  CORE_NS_XSI = "http://www.w3.org/2001/XMLSchema-instance"
+  CORE_NS_XSI = "http://www.w3.org/2001/XMLSchema-instance".freeze
 
   # Digital signature namespace
-  DIGITAL_SIGNATURE_NS = "http://schemas.openxmlformats.org/package/2006/digital-signature"
+  DIGITAL_SIGNATURE_NS = "http://schemas.openxmlformats.org/package/2006/digital-signature".freeze
 
   # spreadsheet drawing namespace
-  XML_NS_XDR = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+  XML_NS_XDR = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing".freeze
 
   # drawing namespace
-  XML_NS_A  = "http://schemas.openxmlformats.org/drawingml/2006/main"
+  XML_NS_A  = "http://schemas.openxmlformats.org/drawingml/2006/main".freeze
 
   # chart namespace
-  XML_NS_C  = "http://schemas.openxmlformats.org/drawingml/2006/chart"
+  XML_NS_C  = "http://schemas.openxmlformats.org/drawingml/2006/chart".freeze
 
   # relationships namespace
-  XML_NS_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  XML_NS_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships".freeze
 
   # relationships name space
-  RELS_R = "http://schemas.openxmlformats.org/package/2006/relationships"
+  RELS_R = "http://schemas.openxmlformats.org/package/2006/relationships".freeze
 
   # table rels namespace
-  TABLE_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/table"
+  TABLE_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/table".freeze
 
   # pivot table rels namespace
-  PIVOT_TABLE_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable"
+  PIVOT_TABLE_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable".freeze
 
   # pivot table cache definition namespace
-  PIVOT_TABLE_CACHE_DEFINITION_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition"
+  PIVOT_TABLE_CACHE_DEFINITION_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition".freeze
 
   # workbook rels namespace
-  WORKBOOK_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
+  WORKBOOK_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument".freeze
 
   # worksheet rels namespace
-  WORKSHEET_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"
+  WORKSHEET_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet".freeze
 
   # app rels namespace
-  APP_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties"
+  APP_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties".freeze
 
   # core rels namespace
-  CORE_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/metadata/core-properties"
+  CORE_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/metadata/core-properties".freeze
 
   # digital signature rels namespace
-  DIGITAL_SIGNATURE_R = "http://schemas.openxmlformats.org/package/2006/relationships/digital- signature/signature"
+  DIGITAL_SIGNATURE_R = "http://schemas.openxmlformats.org/package/2006/relationships/digital- signature/signature".freeze
 
   # styles rels namespace
-  STYLES_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"
+  STYLES_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles".freeze
 
   # shared strings namespace
-  SHARED_STRINGS_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"
+  SHARED_STRINGS_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings".freeze
 
   # drawing rels namespace
-  DRAWING_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing"
+  DRAWING_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing".freeze
 
   # chart rels namespace
-  CHART_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"
+  CHART_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart".freeze
 
   # image rels namespace
-  IMAGE_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
+  IMAGE_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image".freeze
 
   # hyperlink rels namespace
-  HYPERLINK_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"
+  HYPERLINK_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink".freeze
 
   # comment rels namespace
-  COMMENT_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments"
+  COMMENT_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments".freeze
 
   # comment relation for nil target
-  COMMENT_R_NULL = "http://purl.oclc.org/ooxml/officeDocument/relationships/comments"
+  COMMENT_R_NULL = "http://purl.oclc.org/ooxml/officeDocument/relationships/comments".freeze
 
   #vml drawing relation namespace
   VML_DRAWING_R = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/vmlDrawing'
 
   # VML Drawing content type
-  VML_DRAWING_CT = "application/vnd.openxmlformats-officedocument.vmlDrawing"
+  VML_DRAWING_CT = "application/vnd.openxmlformats-officedocument.vmlDrawing".freeze
 
   # table content type
-  TABLE_CT = "application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml"
+  TABLE_CT = "application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml".freeze
 
   # pivot table content type
-  PIVOT_TABLE_CT = "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotTable+xml"
+  PIVOT_TABLE_CT = "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotTable+xml".freeze
 
   # pivot table cache definition content type
-  PIVOT_TABLE_CACHE_DEFINITION_CT = "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"
+  PIVOT_TABLE_CACHE_DEFINITION_CT = "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml".freeze
 
   # workbook content type
-  WORKBOOK_CT = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"
+  WORKBOOK_CT = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml".freeze
 
   # app content type
-  APP_CT = "application/vnd.openxmlformats-officedocument.extended-properties+xml"
+  APP_CT = "application/vnd.openxmlformats-officedocument.extended-properties+xml".freeze
 
   # rels content type
-  RELS_CT = "application/vnd.openxmlformats-package.relationships+xml"
+  RELS_CT = "application/vnd.openxmlformats-package.relationships+xml".freeze
 
   # styles content type
-  STYLES_CT = "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"
+  STYLES_CT = "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml".freeze
 
   # xml content type
-  XML_CT = "application/xml"
+  XML_CT = "application/xml".freeze
 
   # worksheet content type
-  WORKSHEET_CT = "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"
+  WORKSHEET_CT = "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml".freeze
 
   # shared strings content type
-  SHARED_STRINGS_CT = "application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"
+  SHARED_STRINGS_CT = "application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml".freeze
 
   # core content type
-  CORE_CT = "application/vnd.openxmlformats-package.core-properties+xml"
+  CORE_CT = "application/vnd.openxmlformats-package.core-properties+xml".freeze
 
   # digital signature xml content type
-  DIGITAL_SIGNATURE_XML_CT = "application/vnd.openxmlformats-package.digital-signature-xmlsignature+xml"
+  DIGITAL_SIGNATURE_XML_CT = "application/vnd.openxmlformats-package.digital-signature-xmlsignature+xml".freeze
 
   # digital signature origin content type
-  DIGITAL_SIGNATURE_ORIGIN_CT = "application/vnd.openxmlformats-package.digital-signature-origin"
+  DIGITAL_SIGNATURE_ORIGIN_CT = "application/vnd.openxmlformats-package.digital-signature-origin".freeze
 
   # digital signature certificate content type
-  DIGITAL_SIGNATURE_CERTIFICATE_CT = "application/vnd.openxmlformats-package.digital-signature-certificate"
+  DIGITAL_SIGNATURE_CERTIFICATE_CT = "application/vnd.openxmlformats-package.digital-signature-certificate".freeze
 
   # chart content type
-  CHART_CT = "application/vnd.openxmlformats-officedocument.drawingml.chart+xml"
+  CHART_CT = "application/vnd.openxmlformats-officedocument.drawingml.chart+xml".freeze
 
   # comments content type
-  COMMENT_CT = "application/vnd.openxmlformats-officedocument.spreadsheetml.comments+xml"
+  COMMENT_CT = "application/vnd.openxmlformats-officedocument.spreadsheetml.comments+xml".freeze
 
   # jpeg content type
-  JPEG_CT = "image/jpeg"
+  JPEG_CT = "image/jpeg".freeze
 
   # gif content type
-  GIF_CT = "image/gif"
+  GIF_CT = "image/gif".freeze
 
   # png content type
-  PNG_CT = "image/png"
+  PNG_CT = "image/png".freeze
 
   #drawing content type
-  DRAWING_CT = "application/vnd.openxmlformats-officedocument.drawing+xml"
+  DRAWING_CT = "application/vnd.openxmlformats-officedocument.drawing+xml".freeze
 
 
   # xml content type extensions
-  XML_EX = "xml"
+  XML_EX = "xml".freeze
 
   # jpeg extension
-  JPEG_EX = "jpeg"
+  JPEG_EX = "jpeg".freeze
 
   # gif extension
-  GIF_EX = "gif"
+  GIF_EX = "gif".freeze
 
   # png extension
-  PNG_EX = "png"
+  PNG_EX = "png".freeze
 
   # rels content type extension
-  RELS_EX = "rels"
+  RELS_EX = "rels".freeze
 
   # workbook part
-  WORKBOOK_PN = "xl/workbook.xml"
+  WORKBOOK_PN = "xl/workbook.xml".freeze
 
   # styles part
-  STYLES_PN = "styles.xml"
+  STYLES_PN = "styles.xml".freeze
 
   # shared_strings  part
-  SHARED_STRINGS_PN = "sharedStrings.xml"
+  SHARED_STRINGS_PN = "sharedStrings.xml".freeze
 
   # app part
-  APP_PN = "docProps/app.xml"
+  APP_PN = "docProps/app.xml".freeze
 
   # core part
-  CORE_PN = "docProps/core.xml"
+  CORE_PN = "docProps/core.xml".freeze
 
   # content types part
-  CONTENT_TYPES_PN = "[Content_Types].xml"
+  CONTENT_TYPES_PN = "[Content_Types].xml".freeze
 
   # rels part
-  RELS_PN = "_rels/.rels"
+  RELS_PN = "_rels/.rels".freeze
 
   # workbook rels part
-  WORKBOOK_RELS_PN = "xl/_rels/workbook.xml.rels"
+  WORKBOOK_RELS_PN = "xl/_rels/workbook.xml.rels".freeze
 
   # worksheet part
-  WORKSHEET_PN = "worksheets/sheet%d.xml"
+  WORKSHEET_PN = "worksheets/sheet%d.xml".freeze
 
   # worksheet rels part
-  WORKSHEET_RELS_PN = "worksheets/_rels/sheet%d.xml.rels"
+  WORKSHEET_RELS_PN = "worksheets/_rels/sheet%d.xml.rels".freeze
 
   # drawing part
-  DRAWING_PN = "drawings/drawing%d.xml"
+  DRAWING_PN = "drawings/drawing%d.xml".freeze
 
   # drawing rels part
-  DRAWING_RELS_PN = "drawings/_rels/drawing%d.xml.rels"
+  DRAWING_RELS_PN = "drawings/_rels/drawing%d.xml.rels".freeze
 
   # vml drawing part
-  VML_DRAWING_PN = "drawings/vmlDrawing%d.vml"
+  VML_DRAWING_PN = "drawings/vmlDrawing%d.vml".freeze
 
   # drawing part
-  TABLE_PN = "tables/table%d.xml"
+  TABLE_PN = "tables/table%d.xml".freeze
 
   # pivot table parts
-  PIVOT_TABLE_PN = "pivotTables/pivotTable%d.xml"
+  PIVOT_TABLE_PN = "pivotTables/pivotTable%d.xml".freeze
 
   # pivot table cache definition part name
-  PIVOT_TABLE_CACHE_DEFINITION_PN = "pivotCache/pivotCacheDefinition%d.xml"
+  PIVOT_TABLE_CACHE_DEFINITION_PN = "pivotCache/pivotCacheDefinition%d.xml".freeze
 
   # pivot table rels parts
-  PIVOT_TABLE_RELS_PN = "pivotTables/_rels/pivotTable%d.xml.rels"
+  PIVOT_TABLE_RELS_PN = "pivotTables/_rels/pivotTable%d.xml.rels".freeze
 
   # chart part
-  CHART_PN = "charts/chart%d.xml"
+  CHART_PN = "charts/chart%d.xml".freeze
 
   # chart part
-  IMAGE_PN = "media/image%d.%s"
+  IMAGE_PN = "media/image%d.%s".freeze
 
   # comment part
-  COMMENT_PN = "comments%d.xml"
+  COMMENT_PN = "comments%d.xml".freeze
 
   # location of schema files for validation
-  SCHEMA_BASE = File.dirname(__FILE__)+'/../../schema/'
+  SCHEMA_BASE = (File.dirname(__FILE__)+'/../../schema/').freeze
 
   # App validation schema
-  APP_XSD = SCHEMA_BASE + "shared-documentPropertiesExtended.xsd"
+  APP_XSD = (SCHEMA_BASE + "shared-documentPropertiesExtended.xsd").freeze
 
   # core validation schema
-  CORE_XSD = SCHEMA_BASE + "opc-coreProperties.xsd"
+  CORE_XSD = (SCHEMA_BASE + "opc-coreProperties.xsd").freeze
 
   # content types validation schema
-  CONTENT_TYPES_XSD = SCHEMA_BASE + "opc-contentTypes.xsd"
+  CONTENT_TYPES_XSD = (SCHEMA_BASE + "opc-contentTypes.xsd").freeze
 
   # rels validation schema
-  RELS_XSD = SCHEMA_BASE + "opc-relationships.xsd"
+  RELS_XSD = (SCHEMA_BASE + "opc-relationships.xsd").freeze
 
   # spreadsheetML validation schema
-  SML_XSD = SCHEMA_BASE + "sml.xsd"
+  SML_XSD = (SCHEMA_BASE + "sml.xsd").freeze
 
   # drawing validation schema
-  DRAWING_XSD = SCHEMA_BASE + "dml-spreadsheetDrawing.xsd"
+  DRAWING_XSD = (SCHEMA_BASE + "dml-spreadsheetDrawing.xsd").freeze
 
   # number format id for pecentage formatting using the default formatting id.
   NUM_FMT_PERCENT = 9
@@ -275,37 +275,37 @@ module Axlsx
   STYLE_DATE = 2
 
   # error messages RestrictionValidor
-  ERR_RESTRICTION = "Invalid Data: %s. %s must be one of %s."
+  ERR_RESTRICTION = "Invalid Data: %s. %s must be one of %s.".freeze
 
   # error message DataTypeValidator
-  ERR_TYPE = "Invalid Data %s for %s. must be %s."
+  ERR_TYPE = "Invalid Data %s for %s. must be %s.".freeze
 
   # error message for RegexValidator
-  ERR_REGEX = "Invalid Data. %s does not match %s."
+  ERR_REGEX = "Invalid Data. %s does not match %s.".freeze
 
   # error message for RangeValidator
-  ERR_RANGE = "Invalid Data. %s must be between %s and %s, (inclusive:%s) you gave: %s"
+  ERR_RANGE = "Invalid Data. %s must be between %s and %s, (inclusive:%s) you gave: %s".freeze
 
   # error message for sheets that use a name which is longer than 31 bytes
-  ERR_SHEET_NAME_TOO_LONG = "Your worksheet name '%s' is too long. Worksheet names must be 31 characters (bytes) or less"
+  ERR_SHEET_NAME_TOO_LONG = "Your worksheet name '%s' is too long. Worksheet names must be 31 characters (bytes) or less".freeze
 
   # error message for sheets that use a name which include invalid characters
-  ERR_SHEET_NAME_CHARACTER_FORBIDDEN = "Your worksheet name '%s' contains a character which is not allowed by MS Excel and will cause repair warnings. Please change the name of your sheet."
+  ERR_SHEET_NAME_CHARACTER_FORBIDDEN = "Your worksheet name '%s' contains a character which is not allowed by MS Excel and will cause repair warnings. Please change the name of your sheet.".freeze
 
   # error message for duplicate sheet names
-  ERR_DUPLICATE_SHEET_NAME = "There is already a worksheet in this workbook named '%s'. Please use a unique name"
+  ERR_DUPLICATE_SHEET_NAME = "There is already a worksheet in this workbook named '%s'. Please use a unique name".freeze
 
   # error message when user does not provide color and or style options for border in Style#add_sytle
-  ERR_INVALID_BORDER_OPTIONS = "border hash must include both style and color. e.g. :border => { :color => 'FF000000', :style => :thin }. You provided: %s"
+  ERR_INVALID_BORDER_OPTIONS = "border hash must include both style and color. e.g. :border => { :color => 'FF000000', :style => :thin }. You provided: %s".freeze
 
   # error message for invalid border id reference
-  ERR_INVALID_BORDER_ID = "The border id you specified (%s) does not exist. Please add a border with Style#add_style before referencing its index."
+  ERR_INVALID_BORDER_ID = "The border id you specified (%s) does not exist. Please add a border with Style#add_style before referencing its index.".freeze
 
   # error message for invalid angles
-  ERR_ANGLE = "Angles must be a value between -90 and 90. You provided: %s"
+  ERR_ANGLE = "Angles must be a value between -90 and 90. You provided: %s".freeze
 
   # error message for non 'integerish' value
-  ERR_INTEGERISH = "You value must be, or be castable via to_i, an Integer. You provided %s"
+  ERR_INTEGERISH = "You value must be, or be castable via to_i, an Integer. You provided %s".freeze
 
   # Regex to match forbidden control characters
   # The following will be automatically stripped from worksheets.
@@ -383,10 +383,15 @@ module Axlsx
   # x0D Carriage Return (Cr)
   # x09 Character Tabulation
   # @see http://www.codetable.net/asciikeycodes
-  pattern = "[\x0-\x08\x0B\x0C\x0E-\x1F]"
-  pattern= pattern.respond_to?(:encode) ? pattern.encode('UTF-8') : pattern
-
+  pattern = "\x0-\x08\x0B\x0C\x0E-\x1F"
+  pattern = pattern.respond_to?(:encode) ? pattern.encode('UTF-8') : pattern
+  
   # The regular expression used to remove control characters from worksheets
-  CONTROL_CHAR_REGEX = Regexp.new(pattern, 'n')
-
+  CONTROL_CHARS = pattern.freeze
+  
+  ISO_8601_REGEX = /\A(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[0-1]|0[1-9]|[1-2][0-9])T(2[0-3]|[0-1][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[0-1][0-9]):[0-5][0-9])?\Z/.freeze
+  
+  FLOAT_REGEX = /\A[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\Z/.freeze
+  
+  NUMERIC_REGEX = /\A[+-]?\d+?\Z/.freeze
 end

--- a/lib/axlsx/util/options_parser.rb
+++ b/lib/axlsx/util/options_parser.rb
@@ -8,7 +8,8 @@ module Axlsx
     # @param [Hash] options Options to parse.
     def parse_options(options={})
       options.each do |key, value|
-        self.send("#{key}=", value) if self.respond_to?("#{key}=") && value != nil
+        key = :"#{key}="
+        self.send(key, value) if !value.nil? && self.respond_to?(key)
       end
     end
   end

--- a/lib/axlsx/util/parser.rb
+++ b/lib/axlsx/util/parser.rb
@@ -9,28 +9,28 @@ module Axlsx
     
     # parse and assign string attribute
     def parse_string attr_name, xpath
-      send("#{attr_name.to_s}=", parse_value(xpath))
+      send("#{attr_name}=", parse_value(xpath))
     end
     
     # parse convert and assign node text to symbol
     def parse_symbol attr_name, xpath
       v = parse_value xpath
       v = v.to_sym unless v.nil?
-      send("#{attr_name.to_s}=", v)
+      send("#{attr_name}=", v)
     end
     
     # parse, convert and assign note text to integer
     def parse_integer attr_name, xpath
       v = parse_value xpath
       v = v.to_i if v.respond_to?(:to_i)
-      send("#{attr_name.to_s}=", v)
+      send("#{attr_name}=", v)
     end
     
     # parse, convert and assign node text to float
     def parse_float attr_name, xpath
       v = parse_value xpath
       v = v.to_f if v.respond_to?(:to_f)
-      send("#{attr_name.to_s}=", v)
+      send("#{attr_name}=", v)
     end
 
     # return node text based on xpath

--- a/lib/axlsx/util/serialized_attributes.rb
+++ b/lib/axlsx/util/serialized_attributes.rb
@@ -18,9 +18,7 @@ module Axlsx
       end
 
       # a reader for those attributes
-      def xml_attributes
-        @xml_attributes
-      end
+      attr_reader :xml_attributes
 
       # This helper registers the attributes that will be formatted as elements.
       def serializable_element_attributes(*symbols)
@@ -28,8 +26,20 @@ module Axlsx
       end
 
       # attr reader for element attributes
-      def xml_element_attributes
-        @xml_element_attributes
+      attr_reader :xml_element_attributes
+    end
+
+    # creates a XML tag with serialized attributes
+    # @see SerializedAttributes#serialized_attributes
+    def serialized_tag(tagname, str, additional_attributes = {}, &block)
+      str << "<#{tagname} "
+      serialized_attributes(str, additional_attributes)
+      if block_given?
+        str << '>'
+        yield
+        str << "</#{tagname}>"
+      else
+        str << '/>'
       end
     end
 

--- a/lib/axlsx/util/storage.rb
+++ b/lib/axlsx/util/storage.rb
@@ -6,14 +6,14 @@ module Axlsx
 
     # Packing for the Storage when pushing an array of items into a byte stream
     # Name, name length, type, color, left sibling, right sibling, child, classid, state, created, modified, sector, size
-    PACKING = "s32 s1 c2 l3 x16 x4 q2 l q"
+    PACKING = "s32 s1 c2 l3 x16 x4 q2 l q".freeze
 
     # storage types
     TYPES = {
       :root=>5,
       :stream=>2,
       :storage=>1
-    }
+    }.freeze
 
     # Creates a byte string for this storage
     # @return [String] 
@@ -45,7 +45,7 @@ module Axlsx
     # Sets the color for this storage
     # @param [Integer] v Must be one of the COLORS constant hash values
     def color=(v)
-      RestrictionValidator.validate "Storage.color", COLORS.values, v      
+      RestrictionValidator.validate :storage_color, COLORS.values, v      
       @color = v
     end
 
@@ -116,7 +116,7 @@ module Axlsx
     # Sets the type for this storage. 
     # @param [Integer] v the type to specify must be one of the TYPES constant hash values. 
     def type=(v)
-      RestrictionValidator.validate "Storage.type", TYPES.values, v      
+      RestrictionValidator.validate :storage_type, TYPES.values, v      
       @type = v
     end
 

--- a/lib/axlsx/util/string.rb
+++ b/lib/axlsx/util/string.rb
@@ -1,0 +1,7 @@
+unless String.method_defined? :prepend
+  class String
+    def prepend(other_str)
+      insert(0, other_str)
+    end
+  end
+end

--- a/lib/axlsx/workbook/defined_name.rb
+++ b/lib/axlsx/workbook/defined_name.rb
@@ -120,11 +120,9 @@ module Axlsx
 
     def to_xml_string(str='')
       raise ArgumentError, 'you must specify the name for this defined name. Please read the documentation for Axlsx::DefinedName for more details' unless name
-      str << '<definedName '
-      str << 'name="' << name << '" '
+      str << ('<definedName ' << 'name="' << name << '" ')
       serialized_attributes str
-      str << '>' << @formula
-      str << '</definedName>'
+      str << ('>' << @formula << '</definedName>')
     end
   end
 end

--- a/lib/axlsx/workbook/defined_names.rb
+++ b/lib/axlsx/workbook/defined_names.rb
@@ -11,8 +11,8 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      return if @list.empty?
-      str << "<definedNames>"
+      return if empty?
+      str << '<definedNames>'
       each { |defined_name| defined_name.to_xml_string(str) }
       str << '</definedNames>'
     end

--- a/lib/axlsx/workbook/shared_strings_table.rb
+++ b/lib/axlsx/workbook/shared_strings_table.rb
@@ -47,10 +47,10 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str='')
-      str << '<?xml version="1.0" encoding="UTF-8"?><sst xmlns="' << XML_NS << '"'
-      str << ' count="' << @count.to_s << '" uniqueCount="' << unique_count.to_s << '"'
-      str << ' xml:space="' << xml_space.to_s << '">' << @shared_xml_string << '</sst>'
-      str = Axlsx::sanitize(str)
+      Axlsx::sanitize(@shared_xml_string)
+      str << ('<?xml version="1.0" encoding="UTF-8"?><sst xmlns="' << XML_NS << '"')
+      str << (' count="' << @count.to_s << '" uniqueCount="' << unique_count.to_s << '"')
+      str << (' xml:space="' << xml_space.to_s << '">' << @shared_xml_string << '</sst>')
     end
 
     private

--- a/lib/axlsx/workbook/workbook.rb
+++ b/lib/axlsx/workbook/workbook.rb
@@ -338,8 +338,8 @@ require 'axlsx/workbook/worksheet/selection.rb'
     def to_xml_string(str='')
       add_worksheet(name: 'Sheet1') unless worksheets.size > 0
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << '<workbook xmlns="' << XML_NS << '" xmlns:r="' << XML_NS_R << '">'
-      str << '<workbookPr date1904="' << @@date1904.to_s << '"/>'
+      str << ('<workbook xmlns="' << XML_NS << '" xmlns:r="' << XML_NS_R << '">')
+      str << ('<workbookPr date1904="' << @@date1904.to_s << '"/>')
       views.to_xml_string(str)
       str << '<sheets>'
       worksheets.each { |sheet| sheet.to_sheet_node_xml_string(str) }
@@ -348,7 +348,7 @@ require 'axlsx/workbook/worksheet/selection.rb'
       unless pivot_tables.empty?
         str << '<pivotCaches>'
         pivot_tables.each do |pivot_table|
-          str << '<pivotCache cacheId="' << pivot_table.cache_definition.cache_id.to_s << '" r:id="' << pivot_table.cache_definition.rId << '"/>'
+          str << ('<pivotCache cacheId="' << pivot_table.cache_definition.cache_id.to_s << '" r:id="' << pivot_table.cache_definition.rId << '"/>')
         end
         str << '</pivotCaches>'
       end

--- a/lib/axlsx/workbook/workbook_views.rb
+++ b/lib/axlsx/workbook/workbook_views.rb
@@ -11,7 +11,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      return if @list.empty?
+      return if empty?
       str << "<bookViews>"
       each { |view| view.to_xml_string(str) }
       str << '</bookViews>'

--- a/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
@@ -237,9 +237,7 @@ include Axlsx::SerializedAttributes
       # Serialize the object to xml
       # @param [String] str The string object this serialization will be concatenated to.
       def to_xml_string(str = '')
-        str << '<dateGroupItem '
-        serialized_attributes str
-        str << '/>'
+        serialized_tag('dateGroupItem', str)
       end
     end
   end

--- a/lib/axlsx/workbook/worksheet/break.rb
+++ b/lib/axlsx/workbook/worksheet/break.rb
@@ -28,9 +28,7 @@ module Axlsx
 
     # serializes the break to xml
     def to_xml_string(str='')
-      str << '<brk '
-      serialized_attributes str
-      str << '></brk>'
+      serialized_tag('brk', str)
     end
   end
 end

--- a/lib/axlsx/workbook/worksheet/cfvo.rb
+++ b/lib/axlsx/workbook/worksheet/cfvo.rb
@@ -54,9 +54,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<cfvo '
-      serialized_attributes str
-      str << ' />'
+      serialized_tag('cfvo', str)
     end
   end
 end

--- a/lib/axlsx/workbook/worksheet/cfvos.rb
+++ b/lib/axlsx/workbook/worksheet/cfvos.rb
@@ -9,7 +9,7 @@ module Axlsx
     end
 
     def to_xml_string(str='')
-      @list.each { |cfvo| cfvo.to_xml_string(str) }
+      each { |cfvo| cfvo.to_xml_string(str) }
     end
   end
 end

--- a/lib/axlsx/workbook/worksheet/col.rb
+++ b/lib/axlsx/workbook/worksheet/col.rb
@@ -122,22 +122,19 @@ module Axlsx
     # @param [Boolean] use_autowidth If this is false, the cell's
     # autowidth value will be ignored.
     def update_width(cell, fixed_width=nil, use_autowidth=true)
-       if fixed_width.is_a? Numeric
-         self.width = fixed_width
-       elsif use_autowidth
-         cell_width = cell.autowidth
-         self.width = cell_width unless (width || 0) > (cell_width || 0)
-         #self.width = [width || 0, cell.autowidth || 0].max
-       end 
+      if fixed_width.is_a? Numeric
+       self.width = fixed_width
+      elsif use_autowidth
+       cell_width = cell.autowidth
+       self.width = cell_width unless (width || 0) > (cell_width || 0)
+      end 
     end 
 
     # Serialize this columns data to an xml string
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<col '
-      serialized_attributes str
-      str << '/>'
+      serialized_tag('col', str)
     end
 
   end

--- a/lib/axlsx/workbook/worksheet/col_breaks.rb
+++ b/lib/axlsx/workbook/worksheet/col_breaks.rb
@@ -16,7 +16,7 @@ module Axlsx
     # Break will be passed to the created break object.
     # @see Break
     def add_break(options)
-      @list << Break.new(options.merge(:max => 1048575, :man => true))
+      self << Break.new(options.merge(:max => 1048575, :man => true))
       last
     end
 
@@ -27,7 +27,7 @@ module Axlsx
     # </colBreaks>
     def to_xml_string(str='')
       return if empty?
-      str << '<colBreaks count="' << @list.size.to_s << '" manualBreakCount="' << @list.size.to_s << '">'
+      str << ('<colBreaks count="' << size.to_s << '" manualBreakCount="' << size.to_s << '">')
       each { |brk| brk.to_xml_string(str) }
       str << '</colBreaks>'
     end

--- a/lib/axlsx/workbook/worksheet/comment.rb
+++ b/lib/axlsx/workbook/worksheet/comment.rb
@@ -24,10 +24,9 @@ module Axlsx
     string_attr_accessor :text, :author
     boolean_attr_accessor :visible
 
-      # The owning Comments object
+    # The owning Comments object
     # @return [Comments]
     attr_reader :comments
-
 
     # The string based cell position reference (e.g. 'A1') that determines the positioning of this comment
     # @return [String|Cell]
@@ -53,7 +52,7 @@ module Axlsx
 
     # @see ref
     def ref=(v)
-      Axlsx::DataTypeValidator.validate "Comment.ref", [String, Cell], v
+      Axlsx::DataTypeValidator.validate :comment_ref, [String, Cell], v
       @ref = v if v.is_a?(String)
       @ref = v.r if v.is_a?(Cell)
     end
@@ -63,15 +62,15 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = "")
       author = @comments.authors[author_index]
-      str << '<comment ref="' << ref << '" authorId="' << author_index.to_s << '">'
+      str << ('<comment ref="' << ref << '" authorId="' << author_index.to_s << '">')
       str << '<text>'
       unless author.to_s == ""
         str << '<r><rPr><b/><color indexed="81"/></rPr>'
-        str << "<t>" << ::CGI.escapeHTML(author.to_s) << ":\n</t></r>"
+        str << ("<t>" << ::CGI.escapeHTML(author.to_s) << ":\n</t></r>")
       end
       str << '<r>'
       str << '<rPr><color indexed="81"/></rPr>'
-      str << '<t>' << ::CGI.escapeHTML(text) << '</t></r></text>'
+      str << ('<t>' << ::CGI.escapeHTML(text) << '</t></r></text>')
       str << '</comment>'
     end
 

--- a/lib/axlsx/workbook/worksheet/comments.rb
+++ b/lib/axlsx/workbook/worksheet/comments.rb
@@ -42,15 +42,15 @@ module Axlsx
       raise ArgumentError, "Comment require an author" unless options[:author]
       raise ArgumentError, "Comment requires text" unless options[:text]
       raise ArgumentError, "Comment requires ref" unless options[:ref]
-      @list << Comment.new(self, options)
-      yield @list.last if block_given?
-      @list.last
+      self << Comment.new(self, options)
+      yield last if block_given?
+      last
     end
 
     # A sorted list of the unique authors in the contained comments
     # @return [Array]
     def authors
-      @list.map { |comment| comment.author.to_s }.uniq.sort
+      map { |comment| comment.author.to_s }.uniq.sort
     end
 
     # The relationships required by this object
@@ -65,14 +65,12 @@ module Axlsx
     # @return [String]
     def to_xml_string(str="")
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << '<comments xmlns="' << XML_NS << '">'
-      str << '<authors>'
+      str << ('<comments xmlns="' << XML_NS << '"><authors>')
       authors.each do  |author|
-        str << '<author>' << author.to_s << '</author>'
+        str << ('<author>' << author.to_s << '</author>')
       end
-      str << '</authors>'
-      str << '<commentList>'
-      @list.each do |comment|
+      str << '</authors><commentList>'
+      each do |comment|
         comment.to_xml_string str
       end
       str << '</commentList></comments>'

--- a/lib/axlsx/workbook/worksheet/conditional_formatting.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting.rb
@@ -74,7 +74,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<conditionalFormatting sqref="' << sqref << '">'
+      str << ('<conditionalFormatting sqref="' << sqref << '">')
       str << rules.collect{ |rule| rule.to_xml_string }.join(' ')
       str << '</conditionalFormatting>'
     end

--- a/lib/axlsx/workbook/worksheet/conditional_formatting_rule.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting_rule.rb
@@ -210,7 +210,7 @@ module Axlsx
       str << '<cfRule '
       serialized_attributes str
       str << '>'
-      str << '<formula>' << [*self.formula].join('</formula><formula>') << '</formula>' if @formula
+      str << ('<formula>' << [*self.formula].join('</formula><formula>') << '</formula>') if @formula
       @color_scale.to_xml_string(str) if @color_scale && @type == :colorScale
       @data_bar.to_xml_string(str) if @data_bar && @type == :dataBar
       @icon_set.to_xml_string(str) if @icon_set && @type == :iconSet

--- a/lib/axlsx/workbook/worksheet/data_bar.rb
+++ b/lib/axlsx/workbook/worksheet/data_bar.rb
@@ -107,12 +107,10 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str="")
-      str << '<dataBar '
-      serialized_attributes str
-      str << '>'
-      value_objects.to_xml_string(str)
-      self.color.to_xml_string(str)
-      str << '</dataBar>'
+      serialized_tag('dataBar', str) do
+        value_objects.to_xml_string(str)
+        self.color.to_xml_string(str)
+      end
     end
 
     private

--- a/lib/axlsx/workbook/worksheet/data_validation.rb
+++ b/lib/axlsx/workbook/worksheet/data_validation.rb
@@ -33,7 +33,7 @@ module Axlsx
     end
 
     # instance values that must be serialized as their own elements - e.g. not attributes.
-    CHILD_ELEMENTS = [:formula1, :formula2]
+    CHILD_ELEMENTS = [:formula1, :formula2].freeze
 
     # Formula1
     # Available for type whole, decimal, date, time, textLength, list, custom
@@ -218,8 +218,8 @@ module Axlsx
       str << '<dataValidation '
       str << instance_values.map { |key, value| '' << key << '="' << value.to_s << '"' if (valid_attributes.include?(key.to_sym) and not CHILD_ELEMENTS.include?(key.to_sym)) }.join(' ')
       str << '>'
-      str << '<formula1>' << self.formula1 << '</formula1>' if @formula1 and valid_attributes.include?(:formula1)
-      str << '<formula2>' << self.formula2 << '</formula2>' if @formula2 and valid_attributes.include?(:formula2)
+      str << ('<formula1>' << self.formula1 << '</formula1>') if @formula1 and valid_attributes.include?(:formula1)
+      str << ('<formula2>' << self.formula2 << '</formula2>') if @formula2 and valid_attributes.include?(:formula2)
       str << '</dataValidation>'
     end
 

--- a/lib/axlsx/workbook/worksheet/dimension.rb
+++ b/lib/axlsx/workbook/worksheet/dimension.rb
@@ -43,13 +43,13 @@ module Axlsx
     # The first cell in the dimension
     # @return [String]
     def first_cell_reference
-      dimension_reference(worksheet.rows.first.cells.first, Dimension.default_first)
+      dimension_reference(worksheet.rows.first.first, Dimension.default_first)
     end
 
     # the last cell in the dimension
     # @return [String]
     def last_cell_reference
-      dimension_reference(worksheet.rows.last.cells.last, Dimension.default_last)
+      dimension_reference(worksheet.rows.last.last, Dimension.default_last)
     end
 
     private

--- a/lib/axlsx/workbook/worksheet/header_footer.rb
+++ b/lib/axlsx/workbook/worksheet/header_footer.rb
@@ -42,13 +42,11 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << "<headerFooter "
-      serialized_attributes str
-      str << ">"
-      serialized_element_attributes(str) do |value|
-        value = ::CGI.escapeHTML(value)
+      serialized_tag('headerFooter', str) do
+        serialized_element_attributes(str) do |value|
+          value = ::CGI.escapeHTML(value)
+        end
       end
-      str << "</headerFooter>"
     end
   end
 end

--- a/lib/axlsx/workbook/worksheet/icon_set.rb
+++ b/lib/axlsx/workbook/worksheet/icon_set.rb
@@ -63,11 +63,9 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str="")
-      str << '<iconSet '
-      serialized_attributes str
-      str << '>'
-      @value_objects.each { |cfvo| cfvo.to_xml_string(str) }
-      str << '</iconSet>'
+      serialized_tag('iconSet', str) do
+        @value_objects.each { |cfvo| cfvo.to_xml_string(str) }
+      end
     end
 
     private

--- a/lib/axlsx/workbook/worksheet/merged_cells.rb
+++ b/lib/axlsx/workbook/worksheet/merged_cells.rb
@@ -15,7 +15,7 @@ module Axlsx
     # collection. This can be an array of actual cells or a string style
     # range like 'A1:C1'
     def add(cells)
-      @list << if cells.is_a?(String)
+      self << if cells.is_a?(String)
                  cells
                elsif cells.is_a?(Array)
                  Axlsx::cell_range(cells, false)
@@ -26,7 +26,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      return if @list.empty?
+      return if empty?
       str << "<mergeCells count='#{size}'>"
       each { |merged_cell| str << "<mergeCell ref='#{merged_cell}'></mergeCell>" }
       str << '</mergeCells>'

--- a/lib/axlsx/workbook/worksheet/page_margins.rb
+++ b/lib/axlsx/workbook/worksheet/page_margins.rb
@@ -91,9 +91,7 @@ module Axlsx
     # @note For compatibility, this is a noop unless custom margins have been specified.
     # @see #custom_margins_specified?
     def to_xml_string(str = '')
-      str << '<pageMargins '
-      serialized_attributes str
-      str << '/>'
+      serialized_tag('pageMargins', str)
     end
   end
 end

--- a/lib/axlsx/workbook/worksheet/page_set_up_pr.rb
+++ b/lib/axlsx/workbook/worksheet/page_set_up_pr.rb
@@ -38,7 +38,7 @@ module Axlsx
 
     # serialize to xml
     def to_xml_string(str='')
-      str << '<pageSetUpPr ' << serialized_attributes << '/>'
+      str << ('<pageSetUpPr ' << serialized_attributes << '/>')
     end
   end
 end

--- a/lib/axlsx/workbook/worksheet/page_setup.rb
+++ b/lib/axlsx/workbook/worksheet/page_setup.rb
@@ -234,9 +234,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<pageSetup '
-      serialized_attributes str
-      str << '/>'
+      serialized_tag('pageSetup', str)
     end
   end
 end

--- a/lib/axlsx/workbook/worksheet/pane.rb
+++ b/lib/axlsx/workbook/worksheet/pane.rb
@@ -124,9 +124,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       finalize
-      str << '<pane '
-      serialized_attributes str
-      str << '/>'
+      serialized_tag 'pane', str
     end
     private
 

--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -159,9 +159,9 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << '<pivotTableDefinition xmlns="' << XML_NS << '" name="' << name << '" cacheId="' << cache_definition.cache_id.to_s << '"  dataOnRows="1" applyNumberFormats="0" applyBorderFormats="0" applyFontFormats="0" applyPatternFormats="0" applyAlignmentFormats="0" applyWidthHeightFormats="1" dataCaption="Data" showMultipleLabel="0" showMemberPropertyTips="0" useAutoFormatting="1" indent="0" compact="0" compactData="0" gridDropZones="1" multipleFieldFilters="0">'
-      str <<   '<location firstDataCol="1" firstDataRow="1" firstHeaderRow="1" ref="' << ref << '"/>'
-      str <<   '<pivotFields count="' << header_cells_count.to_s << '">'
+      str << ('<pivotTableDefinition xmlns="' << XML_NS << '" name="' << name << '" cacheId="' << cache_definition.cache_id.to_s << '"  dataOnRows="1" applyNumberFormats="0" applyBorderFormats="0" applyFontFormats="0" applyPatternFormats="0" applyAlignmentFormats="0" applyWidthHeightFormats="1" dataCaption="Data" showMultipleLabel="0" showMemberPropertyTips="0" useAutoFormatting="1" indent="0" compact="0" compactData="0" gridDropZones="1" multipleFieldFilters="0">')
+      str << (  '<location firstDataCol="1" firstDataRow="1" firstHeaderRow="1" ref="' << ref << '"/>')
+      str << (  '<pivotFields count="' << header_cells_count.to_s << '">')
       header_cell_values.each do |cell_value|
         str <<   pivot_field_for(cell_value)
       end
@@ -170,12 +170,12 @@ module Axlsx
         str << '<rowFields count="1"><field x="-2"/></rowFields>'
         str << '<rowItems count="2"><i><x/></i> <i i="1"><x v="1"/></i></rowItems>'
       else
-        str << '<rowFields count="' << rows.size.to_s << '">'
+        str << ('<rowFields count="' << rows.size.to_s << '">')
         rows.each do |row_value|
-          str << '<field x="' << header_index_of(row_value).to_s << '"/>'
+          str << ('<field x="' << header_index_of(row_value).to_s << '"/>')
         end
         str << '</rowFields>'
-        str << '<rowItems count="' << rows.size.to_s << '">'
+        str << ('<rowItems count="' << rows.size.to_s << '">')
         rows.size.times do |i|
           str << '<i/>'
         end
@@ -184,16 +184,16 @@ module Axlsx
       if columns.empty?
         str << '<colItems count="1"><i/></colItems>'
       else
-        str << '<colFields count="' << columns.size.to_s << '">'
+        str << ('<colFields count="' << columns.size.to_s << '">')
         columns.each do |column_value|
-          str << '<field x="' << header_index_of(column_value).to_s << '"/>'
+          str << ('<field x="' << header_index_of(column_value).to_s << '"/>')
         end
         str << '</colFields>'
       end
       unless pages.empty?
-        str << '<pageFields count="' << pages.size.to_s << '">'
+        str << ('<pageFields count="' << pages.size.to_s << '">')
         pages.each do |page_value|
-          str << '<pageField fld="' << header_index_of(page_value).to_s << '"/>'
+          str << ('<pageField fld="' << header_index_of(page_value).to_s << '"/>')
         end
         str << '</pageFields>'
       end
@@ -243,31 +243,24 @@ module Axlsx
 
     def pivot_field_for(cell_ref)
       if rows.include? cell_ref
-        '<pivotField axis="axisRow" compact="0" outline="0" subtotalTop="0" showAll="0" includeNewItemsInFilter="1">' <<
-          '<items count="1"><item t="default"/></items>' <<
-        '</pivotField>'
+        '<pivotField axis="axisRow" compact="0" outline="0" subtotalTop="0" showAll="0" includeNewItemsInFilter="1">' + '<items count="1"><item t="default"/></items>' + '</pivotField>'
       elsif columns.include? cell_ref
-        '<pivotField axis="axisCol" compact="0" outline="0" subtotalTop="0" showAll="0" includeNewItemsInFilter="1">' <<
-          '<items count="1"><item t="default"/></items>' <<
-        '</pivotField>'
+        '<pivotField axis="axisCol" compact="0" outline="0" subtotalTop="0" showAll="0" includeNewItemsInFilter="1">' + '<items count="1"><item t="default"/></items>' + '</pivotField>'
       elsif pages.include? cell_ref
-        '<pivotField axis="axisCol" compact="0" outline="0" subtotalTop="0" showAll="0" includeNewItemsInFilter="1">' <<
-          '<items count="1"><item t="default"/></items>' <<
-        '</pivotField>'
+        '<pivotField axis="axisCol" compact="0" outline="0" subtotalTop="0" showAll="0" includeNewItemsInFilter="1">' + '<items count="1"><item t="default"/></items>' + '</pivotField>'
       elsif data_refs.include? cell_ref
-        '<pivotField dataField="1" compact="0" outline="0" subtotalTop="0" showAll="0" includeNewItemsInFilter="1">' <<
-        '</pivotField>'
+        '<pivotField dataField="1" compact="0" outline="0" subtotalTop="0" showAll="0" includeNewItemsInFilter="1">' + '</pivotField>'
       else
-        '<pivotField compact="0" outline="0" subtotalTop="0" showAll="0" includeNewItemsInFilter="1">' <<
-        '</pivotField>'
+        '<pivotField compact="0" outline="0" subtotalTop="0" showAll="0" includeNewItemsInFilter="1">' + '</pivotField>'
       end
     end
+    
     def data_refs
       data.map { |hash| hash[:ref] }
     end
+    
     def header_range
       range.gsub(/^(\w+?)(\d+)\:(\w+?)\d+$/, '\1\2:\3\2')
     end
-
   end
 end

--- a/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
@@ -47,13 +47,13 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << '<pivotCacheDefinition xmlns="' << XML_NS << '" xmlns:r="' << XML_NS_R << '" invalid="1" refreshOnLoad="1" recordCount="0">'
+      str << ('<pivotCacheDefinition xmlns="' << XML_NS << '" xmlns:r="' << XML_NS_R << '" invalid="1" refreshOnLoad="1" recordCount="0">')
       str <<   '<cacheSource type="worksheet">'
-      str <<     '<worksheetSource ref="' << pivot_table.range << '" sheet="' << pivot_table.data_sheet.name << '"/>'
+      str << (    '<worksheetSource ref="' << pivot_table.range << '" sheet="' << pivot_table.data_sheet.name << '"/>')
       str <<   '</cacheSource>'
-      str <<   '<cacheFields count="' << pivot_table.header_cells_count.to_s << '">'
+      str << (  '<cacheFields count="' << pivot_table.header_cells_count.to_s << '">')
       pivot_table.header_cells.each do |cell|
-        str <<   '<cacheField name="' << cell.value << '" numFmtId="0">'
+        str << (  '<cacheField name="' << cell.value << '" numFmtId="0">')
         str <<     '<sharedItems count="0">'
         str <<     '</sharedItems>'
         str <<   '</cacheField>'

--- a/lib/axlsx/workbook/worksheet/print_options.rb
+++ b/lib/axlsx/workbook/worksheet/print_options.rb
@@ -33,9 +33,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<printOptions '
-      serialized_attributes str
-      str << '/>'
+      serialized_tag 'printOptions', str
     end
   end
 end

--- a/lib/axlsx/workbook/worksheet/protected_range.rb
+++ b/lib/axlsx/workbook/worksheet/protected_range.rb
@@ -41,9 +41,7 @@ module Axlsx
     # our output to that object. Use this - it helps limit the number of
     # objects created during serialization
     def to_xml_string(str="")
-      str << '<protectedRange '
-      serialized_attributes str
-      str << '/>'
+      serialized_tag 'protectedRange', str
     end 
   end
 end

--- a/lib/axlsx/workbook/worksheet/protected_ranges.rb
+++ b/lib/axlsx/workbook/worksheet/protected_ranges.rb
@@ -20,7 +20,7 @@ module Axlsx
              elsif cells.is_a?(SimpleTypedList) || cells.is_a?(Array)
                Axlsx::cell_range(cells, false)
              end
-     @list << ProtectedRange.new(:sqref => sqref, :name => "Range#{size}")
+     self << ProtectedRange.new(:sqref => sqref, :name => "Range#{size}")
      last
     end
 

--- a/lib/axlsx/workbook/worksheet/row_breaks.rb
+++ b/lib/axlsx/workbook/worksheet/row_breaks.rb
@@ -14,7 +14,7 @@ module Axlsx
     # @see Break
     def add_break(options)
       # force feed the excel default
-      @list << Break.new(options.merge(:max => 16383, :man => true))
+      self << Break.new(options.merge(:max => 16383, :man => true))
       last
     end
  
@@ -25,7 +25,7 @@ module Axlsx
     # </rowBreaks>
     def to_xml_string(str='')
       return if empty?
-      str << '<rowBreaks count="' << @list.size.to_s << '" manualBreakCount="' << @list.size.to_s << '">'
+      str << ('<rowBreaks count="' << self.size.to_s << '" manualBreakCount="' << self.size.to_s << '">')
       each { |brk| brk.to_xml_string(str) }
       str << '</rowBreaks>'
     end

--- a/lib/axlsx/workbook/worksheet/selection.rb
+++ b/lib/axlsx/workbook/worksheet/selection.rb
@@ -95,9 +95,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<selection '
-      serialized_attributes str
-      str << '/>'
+      serialized_tag 'selection', str
     end
   end
 end

--- a/lib/axlsx/workbook/worksheet/sheet_data.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_data.rb
@@ -17,7 +17,9 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       str << '<sheetData>'
-      worksheet.rows.each_with_index{ |row, index| row.to_xml_string(index, str) }
+      worksheet.rows.each_with_index do |row, index| 
+        row.to_xml_string(index, str) 
+      end
       str << '</sheetData>'
     end
     

--- a/lib/axlsx/workbook/worksheet/sheet_protection.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_protection.rb
@@ -76,9 +76,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<sheetProtection '
-      serialized_attributes str
-      str << '/>'
+      serialized_tag('sheetProtection', str)
     end
 
     private

--- a/lib/axlsx/workbook/worksheet/table.rb
+++ b/lib/axlsx/workbook/worksheet/table.rb
@@ -58,7 +58,7 @@ module Axlsx
     # @param [String, Cell] v
     # @return [Title]
     def name=(v)
-      DataTypeValidator.validate "#{self.class}.name", [String], v
+      DataTypeValidator.validate :table_name, [String], v
       if v.is_a?(String)
         @name = v
       end
@@ -75,12 +75,12 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << '<table xmlns="' << XML_NS << '" id="' << (index+1).to_s << '" name="' << @name << '" displayName="' << @name.gsub(/\s/,'_') << '" '
-      str << 'ref="' << @ref << '" totalsRowShown="0">'
-      str << '<autoFilter ref="' << @ref << '"/>'
-      str << '<tableColumns count="' << header_cells.length.to_s << '">'
+      str << ('<table xmlns="' << XML_NS << '" id="' << (index+1).to_s << '" name="' << @name << '" displayName="' << @name.gsub(/\s/,'_') << '" ')
+      str << ('ref="' << @ref << '" totalsRowShown="0">')
+      str << ('<autoFilter ref="' << @ref << '"/>')
+      str << ('<tableColumns count="' << header_cells.length.to_s << '">')
       header_cells.each_with_index do |cell,index|
-        str << '<tableColumn id ="' << (index+1).to_s << '" name="' << cell.value << '"/>'
+        str << ('<tableColumn id ="' << (index+1).to_s << '" name="' << cell.value << '"/>')
       end
       str << '</tableColumns>'
       table_style_info.to_xml_string(str)

--- a/lib/axlsx/workbook/worksheet/table_style_info.rb
+++ b/lib/axlsx/workbook/worksheet/table_style_info.rb
@@ -43,9 +43,7 @@ module Axlsx
     # seralizes this object to an xml string
     # @param [String] str the string to contact this objects serialization to.
     def to_xml_string(str = '')
-      str << '<tableStyleInfo '
-      serialized_attributes str
-      str << '/>'
+      serialized_tag('tableStyleInfo', str)
     end
   end
 end

--- a/lib/axlsx/workbook/worksheet/tables.rb
+++ b/lib/axlsx/workbook/worksheet/tables.rb
@@ -23,7 +23,7 @@ module Axlsx
     def to_xml_string(str = "")
       return if empty?
       str << "<tableParts count='#{size}'>"
-      @list.each { |table| str << "<tablePart r:id='#{table.rId}'/>" }
+      each { |table| str << "<tablePart r:id='#{table.rId}'/>" }
       str << '</tableParts>'
     end
   end

--- a/lib/axlsx/workbook/worksheet/worksheet_hyperlinks.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet_hyperlinks.rb
@@ -15,8 +15,8 @@ module Axlsx
     # @see WorksheetHyperlink#initialize
     # @return [WorksheetHyperlink]
     def add(options)
-      @list << WorksheetHyperlink.new(@worksheet, options)
-      @list.last
+      self << WorksheetHyperlink.new(@worksheet, options)
+      last
     end
 
     # The relationships required by this collection's hyperlinks
@@ -31,7 +31,7 @@ module Axlsx
     def to_xml_string(str='')
       return if empty?
       str << '<hyperlinks>'
-      @list.each { |hyperlink| hyperlink.to_xml_string(str) }
+      each { |hyperlink| hyperlink.to_xml_string(str) }
       str << '</hyperlinks>'
     end
   end

--- a/test/util/tc_simple_typed_list.rb
+++ b/test/util/tc_simple_typed_list.rb
@@ -72,7 +72,6 @@ class TestSimpleTypedList < Test::Unit::TestCase
   def test_equality
     @list.push 1
     @list.push 2
-    assert_equal(@list, [1,2])
-    
+    assert_equal(@list.to_ary, [1,2])
   end
 end

--- a/test/workbook/worksheet/tc_cell.rb
+++ b/test/workbook/worksheet/tc_cell.rb
@@ -34,7 +34,7 @@ class TestCell < Test::Unit::TestCase
   end
 
   def test_pos
-    assert_equal(@c.pos, [@c.index, @c.row.index])
+    assert_equal(@c.pos, [@c.index, @c.row.index(@c)])
   end
 
   def test_r

--- a/test/workbook/worksheet/tc_row.rb
+++ b/test/workbook/worksheet/tc_row.rb
@@ -29,7 +29,7 @@ class TestRow < Test::Unit::TestCase
 
 
   def test_index
-    assert_equal(@row.index, @row.worksheet.rows.index(@row))
+    assert_equal(@row.row_index, @row.worksheet.rows.index(@row))
   end
 
   def test_add_cell

--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -398,10 +398,13 @@ class TestWorksheet < Test::Unit::TestCase
   end
 
   def test_to_xml_string_with_illegal_chars
+    old = Axlsx::trust_input
+    Axlsx::trust_input = false
     nasties =  "\v\u2028\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u001f"
     @ws.add_row [nasties]
-    assert_equal(0, @ws.rows.last.cells.last.value.index("\v"))
-    assert_equal(nil,@ws.to_xml_string.index("\v"))
+    assert_equal(nil, @ws.rows.last.cells.last.value.index("\v"))
+    assert_equal(nil, @ws.to_xml_string.index("\v"))
+    Axlsx::trust_input = old
   end
 
   def test_to_xml_string_with_newlines


### PR DESCRIPTION
Do not create huge strings
Let SimpleTypedList inherit from Array
Let Row inherit from SimpleTypedList
Optimized sanitizing
Optimized validation
And more..

The parentheses around the << calls are because of the following bug in ruby-zip: [using chained #<< will create a damaged zip file](https://github.com/rubyzip/rubyzip/issues/135). They can be removed after ruby-zip is fixed.
