### PR TITLE
Add zip-zip gem for compatibility with new rubyzip

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'nokogiri', '>= 1.4.1'
   s.add_runtime_dependency 'rubyzip', '~> 1.1.0'
+  s.add_runtime_dependency "zip-zip", "~> 0.2"
   s.add_runtime_dependency "htmlentities", "~> 4.3.1"
 
   s.add_development_dependency 'yard'


### PR DESCRIPTION
Axlsx uses the old Rubyzip interface. Gem 'zip-zip' is a compatibility layer.
See randym/axlsx#234
