### PR TITLE
Dependency update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem "rake", ">= 0.8.7"
-  gem "simplecov"
+  gem 'rake', '>= 0.8.7'
+  gem 'simplecov'
+  gem 'nokogiri', '>= 1.4.1'
 end
 
 group :profile do
@@ -16,3 +17,10 @@ platforms :rbx do
   gem 'racc'
   gem 'rubinius-coverage',  '~> 2.0'
 end
+
+platform :mri do
+  if RUBY_VERSION > "1.9.2"
+    gem 'escape_utils', '~> 1.0.1' 
+  end
+end
+

--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -3,27 +3,27 @@ require File.expand_path('../lib/axlsx/version', __FILE__)
 Gem::Specification.new do |s|
   s.name        = 'axlsx'
   s.version     = Axlsx::VERSION
-  s.author	= "Randy Morgan"
+  s.author	= 'Randy Morgan'
   s.email       = 'digital.ipseity@gmail.com'
   s.homepage 	= 'https://github.com/randym/axlsx'
   s.platform    = Gem::Platform::RUBY
   s.date        = Time.now.strftime('%Y-%m-%d')
-  s.summary     = "excel OOXML (xlsx) with charts, styles, images and autowidth columns."
+  s.summary     = 'Excel OOXML (xlsx) with charts, styles, images and autowidth columns.'
   s.has_rdoc    = 'axlsx'
   s.license     = 'MIT'
   s.description = <<-eof
     xlsx spreadsheet generation with charts, images, automated column width, customizable styles and full schema validation. Axlsx helps you create beautiful Office Open XML Spreadsheet documents ( Excel, Google Spreadsheets, Numbers, LibreOffice) without having to understand the entire ECMA specification. Check out the README for some examples of how easy it is. Best of all, you can validate your xlsx file before serialization so you know for sure that anything generated is going to load on your client's machine.
   eof
-  s.files = Dir.glob("{lib/**/*,examples/**/*.rb,examples/**/*.jpeg}") + %w{ LICENSE README.md Rakefile CHANGELOG.md .yardopts .yardopts_guide }
-  s.test_files  = Dir.glob("{test/**/*}")
+  s.files = Dir.glob('{lib/**/*,examples/**/*.rb,examples/**/*.jpeg}') + %w{ LICENSE README.md Rakefile CHANGELOG.md .yardopts .yardopts_guide }
+  s.test_files  = Dir.glob('{test/**/*}')
 
-  s.add_runtime_dependency 'nokogiri', '>= 1.4.1'
   s.add_runtime_dependency 'rubyzip', '~> 1.1.1'
-  s.add_runtime_dependency "htmlentities", "~> 4.3.1"
+  s.add_runtime_dependency 'htmlentities', '~> 4.3.1'
 
   s.add_development_dependency 'yard'
   s.add_development_dependency 'kramdown'
-  s.add_development_dependency 'timecop', "~> 0.6.1"
+  s.add_development_dependency 'timecop', '~> 0.6.1'
+  
   s.required_ruby_version = '>= 1.9.2'
   s.require_path = 'lib'
 end

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -22,9 +22,16 @@ require 'axlsx/rels/relationships.rb'
 require 'axlsx/drawing/drawing.rb'
 require 'axlsx/workbook/workbook.rb'
 require 'axlsx/package.rb'
+
 #required gems
-require 'nokogiri'
 require 'zip'
+
+#optional gems
+begin
+  require 'escape_utils'
+  require 'escape_utils/html/cgi'
+rescue LoadError
+end
 
 #core dependencies
 require 'bigdecimal'

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -263,6 +263,7 @@ module Axlsx
     # @return [Array] An array of all validation errors encountered.
     # @private
     def validate_single_doc(schema, doc)
+      require 'nokogiri'
       schema = Nokogiri::XML::Schema(File.open(schema))
       doc = Nokogiri::XML(doc)
       errors = []
@@ -270,6 +271,8 @@ module Axlsx
         errors << error
       end
       errors
+    rescue
+      warn "Please install Nokogiri if you want to validate your documents."
     end
 
     # Appends override objects for drawings, charts, and sheets as they exist in your workbook to the default content types.

--- a/test/tc_helper.rb
+++ b/test/tc_helper.rb
@@ -7,4 +7,5 @@ end
 
 require 'test/unit'
 require "timecop"
+require 'nokogiri'
 require "axlsx.rb"


### PR DESCRIPTION
Speed up escaping by using escape_utils when available and make the Nokogiri dependency optional.