### PR TITLE
Allow both minor and patch changes in dependencies

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |s|
   s.test_files  = Dir.glob("{test/**/*}")
 
   s.add_runtime_dependency 'nokogiri', '>= 1.4.1'
-  s.add_runtime_dependency 'rubyzip', '~> 1.1.1'
-  s.add_runtime_dependency "htmlentities", "~> 4.3.1"
+  s.add_runtime_dependency 'rubyzip', '~> 1.1'
+  s.add_runtime_dependency "htmlentities", "~> 4.3"
 
   s.add_development_dependency 'yard'
   s.add_development_dependency 'kramdown'
-  s.add_development_dependency 'timecop', "~> 0.6.1"
+  s.add_development_dependency 'timecop', "~> 0.6"
   s.required_ruby_version = '>= 1.9.2'
   s.require_path = 'lib'
 end


### PR DESCRIPTION
The optimistic operator `~>` is tricky. I only recently learned how it works. The level of precision determines what ranges are allowed (http://guides.rubygems.org/patterns/).

With the current gemspec `rubyzip` and `htmlentities` are pinned down to only path level changes. This change allows `rubyzip >= 1.1 && < 2.0` which is fine.

Only allowing patch level changes causes needless dependency issues.

This adjustment is theoretically safe as long as semantic versioning is adhered to by the dependencies.
