### PR TITLE
Add test to confirm control characters are removed from shared strings

### DIFF
--- a/lib/axlsx/version.rb
+++ b/lib/axlsx/version.rb
@@ -1,5 +1,5 @@
 module Axlsx
 
   # The current version
-  VERSION = "2.0.1"
+  # VERSION = "2.0.1"
 end

--- a/test/workbook/tc_shared_strings_table.rb
+++ b/test/workbook/tc_shared_strings_table.rb
@@ -41,4 +41,18 @@ class TestSharedStringsTable < Test::Unit::TestCase
     assert_equal(errors.size, 0, "sharedStirngs.xml Invalid" + errors.map{ |e| e.message }.to_s)
   end
 
+  def test_remove_control_characters_in_xml_serialization
+    nasties =  "hello\x10\x00\x1C\x1Eworld"
+    @p.workbook.worksheets[0].add_row [nasties]
+
+    # test that the nasty string was added to the shared strings
+    assert @p.workbook.shared_strings.unique_cells.has_key?(nasties)
+
+    # test that none of the control characters are in the XML output for shared strings
+    assert_no_match /#{Axlsx::CONTROL_CHARS}/, @p.workbook.shared_strings.to_xml_string
+
+    # assert that the shared string was normalized to remove the control characters
+    assert_not_nil @p.workbook.shared_strings.to_xml_string.index("helloworld")
+  end
+
 end


### PR DESCRIPTION
* Commit f8ef8eb78eb4556676b5770c82493e6e6edf7ec8 fixed the shared
  strings class to automatically sanitize its serialized XML output to
  remove any control characters. However, this commit did not include
  tests that the shared strings actually removed the control
  characters when serializing to an XML string.
  * This tests confirms that the string with control characters is
    added to the shared strings, and that the control characters are
    removed from the string in question when serialized to XML.