### PR TITLE
Add support for enabling or disabling smoothed lines in a scatter series

### DIFF
--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -21,9 +21,21 @@ module Axlsx
     # @return [String]
     attr_reader :color
 
+    # Line smoothing between data points
+    # @return [Boolean]
+    attr_reader :smooth
+    
     # Creates a new ScatterSeries
     def initialize(chart, options={})
       @xData, @yData = nil
+      if options[:smooth].nil?
+        # If caller hasn't specified smoothing or not, turn smoothing on or off based on scatter style
+        @smooth = [:smooth, :smoothMarker].include?(chart.scatter_style)
+      else
+        # Set smoothing according to the option provided
+        Axlsx::validate_boolean(options[:smooth])
+        @smooth = options[:smooth]
+      end
       super(chart, options)
       @xData = AxDataSource.new(:tag_name => :xVal, :data => options[:xData]) unless options[:xData].nil?
       @yData = NumDataSource.new({:tag_name => :yVal, :data => options[:yData]}) unless options[:yData].nil?
@@ -34,6 +46,12 @@ module Axlsx
       @color = v
     end
 
+    # @see smooth
+    def smooth=(v)
+      Axlsx::validate_boolean(v)
+      @smooth = v
+    end
+    
     # Serializes the object
     # @param [String] str
     # @return [String]
@@ -58,6 +76,7 @@ module Axlsx
         end
         @xData.to_xml_string(str) unless @xData.nil?
         @yData.to_xml_string(str) unless @yData.nil?
+        str << ('<c:smooth val="' << ((smooth) ? '1' : '0') << '"/>')
       end
       str
     end

--- a/test/drawing/tc_scatter_series.rb
+++ b/test/drawing/tc_scatter_series.rb
@@ -34,7 +34,7 @@ class TestScatterSeries < Test::Unit::TestCase
   def test_explicit_unsmoothing
     @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Smooth Chart, Unsmooth Series", :scatter_style => :smoothMarker
     @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9], :title=>"unsmoothed exponents", :smooth => false
-    assert(!@series.smooth"series is not smooth when overriding chart default")
+    assert(!@series.smooth, "series is not smooth when overriding chart default")
   end    
 
   def test_to_xml_string

--- a/test/drawing/tc_scatter_series.rb
+++ b/test/drawing/tc_scatter_series.rb
@@ -6,12 +6,36 @@ class TestScatterSeries < Test::Unit::TestCase
     p = Axlsx::Package.new
     @ws = p.workbook.add_worksheet :name=>"hmmm"
     @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Scatter Chart"
-    @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9], :title=>"exponents", :color => 'FF0000'
+    @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9], :title=>"exponents", :color => 'FF0000', :smooth => true
   end
 
   def test_initialize
     assert_equal(@series.title.text, "exponents", "series title has been applied")
   end
+
+  def test_smoothed_chart_default_smoothing
+    @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Smooth Chart", :scatter_style => :smoothMarker
+    @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9], :title=>"smoothed exponents"
+    assert(@series.smooth, "series is smooth by default on smooth charts")
+  end
+  
+  def test_unsmoothed_chart_default_smoothing
+    @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Unsmooth Chart", :scatter_style => :line
+    @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9], :title=>"unsmoothed exponents"
+    assert(!@series.smooth, "series is not smooth by default on non-smooth charts")
+  end
+  
+  def test_explicit_smoothing
+    @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Unsmooth Chart, Smooth Series", :scatter_style => :line
+    @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9], :title=>"smoothed exponents", :smooth => true
+    assert(@series.smooth, "series is smooth when overriding chart default")
+  end    
+  
+  def test_explicit_unsmoothing
+    @chart = @ws.add_chart Axlsx::ScatterChart, :title => "Smooth Chart, Unsmooth Series", :scatter_style => :smoothMarker
+    @series = @chart.add_series :xData=>[1,2,4], :yData=>[1,3,9], :title=>"unsmoothed exponents", :smooth => false
+    assert(!@series.smooth"series is not smooth when overriding chart default")
+  end    
 
   def test_to_xml_string
     doc = Nokogiri::XML(@chart.to_xml_string)


### PR DESCRIPTION
I noticed I was getting line smoothing even when a scatter chart's scatter style was set to a non-smoothed one. This change should set the series smoothing defaults based on scatter style of the chart but also allows smoothing to be enabled or disabled on a per-series basis.

Unfortunately this seems to be Excel-specific behaviour and is technically in violation of the Office Open XML standard (see http://msdn.microsoft.com/en-us/library/ff535259(v=office.12).aspx) but since Excel isn't compliant with the standard, I don't see another way to do this and have it work in Excel.

I added tests for default smooth settings and overriding smooth settings.