### PR TITLE
Skip to_time if the value is a Time instance

### DIFF
--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -452,7 +452,11 @@ module Axlsx
         v
       when :time
         self.style = STYLE_DATE if self.style == 0
-        v.respond_to?(:to_time) ? v.to_time : v
+        if !v.is_a?(Time) && v.respond_to?(:to_time)
+          v.to_time
+        else
+          v
+        end
       when :float
         v.to_f
       when :integer

--- a/test/workbook/worksheet/tc_cell.rb
+++ b/test/workbook/worksheet/tc_cell.rb
@@ -119,6 +119,19 @@ class TestCell < Test::Unit::TestCase
     assert_equal("2012-10-10T12:24", @c.send(:cast_value, "2012-10-10T12:24"))
   end
 
+  def test_cast_time_subclass
+    subtime = Class.new(Time) do
+      def to_time
+        raise "#to_time of Time subclass should not be called"
+      end
+    end
+
+    time = subtime.now
+
+    @c.type = :time
+    assert_equal(time, @c.send(:cast_value, time))
+  end
+
   def test_color
     assert_raise(ArgumentError) { @c.color = -1.1 }
     assert_nothing_raised { @c.color = "FF00FF00" }


### PR DESCRIPTION
This patch is to fix incorrect output of a cell associated with an instance of `ActiveSupport::TimeWithZone`.

`TimeWithZone` has an instance method `to_time` and `Axlsx::Cell#cast_value` will call it. However, the returned value of `TimeWithZone#to_time` is an instance of `Time` and and it is without instance specific time zone. The output Excel file may contain incorrect local time.

If the value `is_a?(Time)`, usually it means the class is a subclass of `Time`, there should be no need to call `#to_time` explicitly.