### PR TITLE
bump version to 2.0.2

### DIFF
--- a/lib/axlsx/version.rb
+++ b/lib/axlsx/version.rb
@@ -1,5 +1,5 @@
 module Axlsx
 
   # The current version
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 end


### PR DESCRIPTION
My motivation for wanting a new version is the updated rubyzip dependency in
the gemspec. I've had dependency problems with axlsx because version 2.0.1 insists upon rubyzip ~> 1.0.0.