### PR TITLE
Make alpha option accessible for pictures 

### DIFF
--- a/lib/axlsx/drawing/pic.rb
+++ b/lib/axlsx/drawing/pic.rb
@@ -23,6 +23,7 @@ module Axlsx
       start_at(*options[:start_at]) if options[:start_at]
       yield self if block_given?
       @picture_locking = PictureLocking.new(options)
+      @alpha = options[:alpha] if options[:alpha]
     end
 
     # allowed file extenstions
@@ -171,7 +172,11 @@ module Axlsx
       picture_locking.to_xml_string(str)
       str << '</xdr:cNvPicPr></xdr:nvPicPr>'
       str << '<xdr:blipFill>'
-      str << ('<a:blip xmlns:r ="' << XML_NS_R << '" r:embed="' << relationship.Id << '"/>')
+      str << ('<a:blip xmlns:r ="' << XML_NS_R << '" r:embed="' << relationship.Id << '">')
+      if @alpha
+        str << "<a:alphaModFix amt=\"#{@alpha}\"/>"
+      end
+      str << '</a:blip>'
       str << '<a:stretch><a:fillRect/></a:stretch></xdr:blipFill><xdr:spPr>'
       str << '<a:xfrm><a:off x="0" y="0"/><a:ext cx="2336800" cy="2161540"/></a:xfrm>'
       str << '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></xdr:spPr></xdr:pic>'

--- a/lib/axlsx/drawing/pic.rb
+++ b/lib/axlsx/drawing/pic.rb
@@ -23,7 +23,7 @@ module Axlsx
       start_at(*options[:start_at]) if options[:start_at]
       yield self if block_given?
       @picture_locking = PictureLocking.new(options)
-      @alpha = options[:alpha] if options[:alpha]
+      @opacity = options[:opacity] * 100000 if options[:opacity] #accepts value beween 0..1
     end
 
     # allowed file extenstions
@@ -173,8 +173,8 @@ module Axlsx
       str << '</xdr:cNvPicPr></xdr:nvPicPr>'
       str << '<xdr:blipFill>'
       str << ('<a:blip xmlns:r ="' << XML_NS_R << '" r:embed="' << relationship.Id << '">')
-      if @alpha
-        str << "<a:alphaModFix amt=\"#{@alpha}\"/>"
+      if @opacity
+        str << "<a:alphaModFix amt=\"#{@opacity}\"/>"
       end
       str << '</a:blip>'
       str << '<a:stretch><a:fillRect/></a:stretch></xdr:blipFill><xdr:spPr>'

--- a/lib/axlsx/drawing/pic.rb
+++ b/lib/axlsx/drawing/pic.rb
@@ -23,7 +23,7 @@ module Axlsx
       start_at(*options[:start_at]) if options[:start_at]
       yield self if block_given?
       @picture_locking = PictureLocking.new(options)
-      @opacity = options[:opacity] * 100000 if options[:opacity] #accepts value beween 0..1
+      @opacity = (options[:opacity] * 100000).round if options[:opacity] #accepts value beween 0..1
     end
 
     # allowed file extenstions


### PR DESCRIPTION
I needed to access transparency on images for a project, here's my quick and dirty patch to make that accessible. I'm open to feedback on how to make this pull request better fit into your project.

0 = transparent  100000 = opaque

It might make sense to multiply the value by 10,000 and subtract from 100,000 to get to an alpha percentage value. 