### PR TITLE
Fix content types for uppercased image file extensions

### DIFF
--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -314,7 +314,7 @@ module Axlsx
         c_types << Axlsx::Override.new(:PartName => "/xl/#{sheet.pn}",
                                          :ContentType => WORKSHEET_CT)
       end
-      exts = workbook.images.map { |image| image.extname }
+      exts = workbook.images.map { |image| image.extname.downcase }
       exts.uniq.each do |ext|
         ct = if  ['jpeg', 'jpg'].include?(ext)
                JPEG_CT

--- a/test/drawing/tc_pic.rb
+++ b/test/drawing/tc_pic.rb
@@ -79,6 +79,10 @@ class TestPic < Test::Unit::TestCase
 
   def test_image_src_downcase
     assert_nothing_raised { @image.image_src = @test_img_up }
+    ct = @p.send(:content_types).detect do |t|
+      t.respond_to?(:extension) && t.extension.downcase == @image.extname.downcase
+    end
+    assert_equal("image/jpeg", ct.content_type)
   end
 
   def test_descr


### PR DESCRIPTION
Previously content types were only added for jpg, png,.. (lowercase) extensions, now it also adds content types for JPG, PNG... (uppercase)