### PR TITLE
Make comments work in office for mac 2015

### DIFF
--- a/lib/axlsx/workbook/worksheet/comment.rb
+++ b/lib/axlsx/workbook/worksheet/comment.rb
@@ -66,11 +66,11 @@ module Axlsx
       str << '<text>'
       unless author.to_s == ""
         str << '<r><rPr><b/><color indexed="81"/></rPr>'
-        str << ("<t>" << ::CGI.escapeHTML(author.to_s) << ":\n</t></r>")
+        str << ('<t xml:space="preserve">' << ::CGI.escapeHTML(author.to_s) << ":\n</t></r>")
       end
       str << '<r>'
       str << '<rPr><color indexed="81"/></rPr>'
-      str << ('<t>' << ::CGI.escapeHTML(text) << '</t></r></text>')
+      str << ('<t xml:space="preserve">' << ::CGI.escapeHTML(text) << '</t></r></text>')
       str << '</comment>'
     end
 
@@ -82,9 +82,9 @@ module Axlsx
       pos = Axlsx::name_to_indices(ref)
       @vml_shape = VmlShape.new(:row => pos[1], :column => pos[0], :visible => @visible) do |vml|
         vml.left_column = vml.column
-        vml.right_column = vml.column + 2 
+        vml.right_column = vml.column + 2
         vml.top_row = vml.row
-         vml.bottom_row = vml.row + 4
+        vml.bottom_row = vml.row + 4
       end
     end
   end

--- a/lib/schema/sml.xsd
+++ b/lib/schema/sml.xsd
@@ -10,7 +10,7 @@
     schemaLocation="shared-relationshipReference.xsd"/>
   <xsd:import namespace="http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes"
     schemaLocation="shared-commonSimpleTypes.xsd"/>
-  <xsd:import 
+  <xsd:import
     namespace="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
     schemaLocation="dml-spreadsheetDrawing.xsd"/>
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
@@ -1827,7 +1827,7 @@
   <xsd:complexType name="CT_RElt">
     <xsd:sequence>
       <xsd:element name="rPr" type="CT_RPrElt" minOccurs="0" maxOccurs="1"/>
-      <xsd:element name="t" type="s:ST_Xstring" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="t" type="CT_StringWithSpace" minOccurs="1" maxOccurs="1"/>
     </xsd:sequence>
   </xsd:complexType>
   <xsd:complexType name="CT_RPrElt">
@@ -1851,11 +1851,18 @@
   </xsd:complexType>
   <xsd:complexType name="CT_Rst">
     <xsd:sequence>
-      <xsd:element name="t" type="s:ST_Xstring" minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="t" type="CT_StringWithSpace" minOccurs="0" maxOccurs="1"/>
       <xsd:element name="r" type="CT_RElt" minOccurs="0" maxOccurs="unbounded"/>
       <xsd:element name="rPh" type="CT_PhoneticRun" minOccurs="0" maxOccurs="unbounded"/>
       <xsd:element name="phoneticPr" minOccurs="0" maxOccurs="1" type="CT_PhoneticPr"/>
     </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="CT_StringWithSpace">
+    <xsd:simpleContent>
+      <xsd:extension base="s:ST_Xstring">
+        <xsd:attribute ref="xml:space"/>
+      </xsd:extension>
+    </xsd:simpleContent>
   </xsd:complexType>
   <xsd:complexType name="CT_PhoneticPr">
     <xsd:attribute name="fontId" type="ST_FontId" use="required"/>


### PR DESCRIPTION
Hi!

Office for Mac 2015 don't show comments without 'xml:space' attribute.
Here is comments.xml extracted from xlsx file, created with Office:
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<comments xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
  <authors><author>Пользователь Microsoft Office</author></authors>
  <commentList>
    <comment ref="C5" authorId="0">
      <text><r><rPr><b/><sz val="10"/><color indexed="81"/><rFont val="Calibri"/></rPr><t xml:space="preserve">test comment</t></r></text>
    </comment>
  </commentList>
</comments>
```
I can't test another office versions, but xlsx files exported from google docs also contains this attribute.