### PR TITLE
autoset worksheet name if options[:name] is nil

### DIFF
--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -24,6 +24,7 @@ module Axlsx
       parse_options options
       @workbook.worksheets << self
       @sheet_id = index + 1
+      name
       yield self if block_given?
     end
 

--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -266,6 +266,11 @@ class TestWorksheet < Test::Unit::TestCase
     end
   end
 
+  def test_to_sheet_node_xml_string_without_name
+    doc = Nokogiri::XML(@ws.to_sheet_node_xml_string)
+    assert_equal(doc.xpath('/sheet/@name').size, 1)
+  end
+
   def test_to_xml_string_fit_to_page
     @ws.page_setup.fit_to_width = 1
     doc = Nokogiri::XML(@ws.to_xml_string)


### PR DESCRIPTION
axlsx generates broken package if worksheet initialized without :name option. An example to reproduce the issue:
```ruby
Axlsx::Package.new do |p|
  p.workbook.add_worksheet { |sheet| sheet.add_row ["test"] }  
  p.serialize('test.xlsx') 
end  
```

MS Excel can't open packages containing a worksheet without name (Excel could not open test.xlsx because some content is unreadable.)

```xml
<!-- test.xlsx/xl/workbook.xml -->
<?xml version="1.0" encoding="UTF-8"?>
<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
<workbookPr date1904="false"/>
  <sheets>
    <sheet sheetId="1" r:id="rId4"></sheet>
  </sheets>
</workbook>
```

tested with latest MSO on OSX and iOS