### PR TITLE
Small performance improvements

### DIFF
--- a/lib/axlsx/util/simple_typed_list.rb
+++ b/lib/axlsx/util/simple_typed_list.rb
@@ -82,9 +82,9 @@ module Axlsx
     # one of the allowed types
     # @return [SimpleTypedList]
     def +(v)
-      v.each do |item| 
-        DataTypeValidator.validate :SimpleTypedList_plus, @allowed_types, item
-        @list << item 
+      v.each do |item|
+        validate_element(v)
+        @list << item
       end
     end
 
@@ -93,7 +93,7 @@ module Axlsx
     # @raise [ArgumentError] if the value being added is not one fo the allowed types
     # @return [Integer] returns the index of the item added.
     def <<(v)
-      DataTypeValidator.validate :SimpleTypedList_push, @allowed_types, v
+      validate_element(v)
       @list << v
       @list.size - 1
     end 
@@ -126,10 +126,23 @@ module Axlsx
     # @raise [ArgumentError] if the index is protected by locking
     # @raise [ArgumentError] if the item is not one of the allowed types
     def []=(index, v)
-      DataTypeValidator.validate :SimpleTypedList_insert, @allowed_types, v
+      validate_element(v)
       raise ArgumentError, "Item is protected and cannot be changed" if protected? index
       @list[index] = v
       v
+    end
+
+    def validate_element(v)
+      if @allowed_types.size == 1
+        unless v.is_a?(@allowed_types.first)
+          raise ArgumentError, "element should be instance of #{@allowed_types.inspect}"
+        end
+      else
+        @allowed_types.each do |klass|
+          return if v.is_a?(klass)
+        end
+        raise ArgumentError, "element should be instance of #{@allowed_types.inspect}"
+      end
     end
 
     # inserts an item at the index specfied
@@ -138,7 +151,7 @@ module Axlsx
     # @raise [ArgumentError] if the index is protected by locking
     # @raise [ArgumentError] if the index is not one of the allowed types
     def insert(index, v)
-      DataTypeValidator.validate :SimpleTypedList_insert, @allowed_types, v
+      validate_element(v)
       raise ArgumentError, "Item is protected and cannot be changed" if protected? index
       @list.insert(index, v)
       v
@@ -147,8 +160,7 @@ module Axlsx
     # determines if the index is protected
     # @param [Integer] index
     def protected? index
-      return false unless locked_at.is_a? Fixnum
-      index < locked_at
+      return index < (@locked_at || -1)
     end
 
     DESTRUCTIVE = ['replace', 'insert', 'collect!', 'map!', 'pop', 'delete_if',
@@ -164,7 +176,7 @@ module Axlsx
         end
       }
     end
-                   
+
     def to_xml_string(str = '')
       classname = @allowed_types[0].name.split('::').last
       el_name = serialize_as.to_s || (classname[0,1].downcase + classname[1..-1])

--- a/lib/axlsx/workbook/worksheet/cell_serializer.rb
+++ b/lib/axlsx/workbook/worksheet/cell_serializer.rb
@@ -8,13 +8,14 @@ module Axlsx
       # @param [Integer] column_index The index of the cell's column
       # @param [String] str The string to apend serialization to.
       # @return [String]
-      def to_xml_string(row_index, column_index, cell, str='')
-        str << ('<c r="' << Axlsx::cell_r(column_index, row_index) << '" s="' << cell.style.to_s << '" ')
+
+      def to_xml_string(row_index, column_index, cell, str = '')
+        str << %{<c r="#{Axlsx::cell_r(column_index, row_index)}" s="#{cell.style.to_s}" }
         return str << '/>' if cell.value.nil?
         method = cell.type
         self.send(method, cell, str)
         str << '</c>'
-      end 
+      end
 
       # builds an xml text run based on this cells attributes.
       # @param [String] str The string instance this run will be concated to.

--- a/lib/axlsx/workbook/worksheet/row.rb
+++ b/lib/axlsx/workbook/worksheet/row.rb
@@ -141,7 +141,9 @@ module Axlsx
     def array_to_cells(values, options={})
       DataTypeValidator.validate :array_to_cells, Array, values
       types, style, formula_values = options.delete(:types), options.delete(:style), options.delete(:formula_values)
-      values.each_with_index do |value, index|
+
+      values.size.times do |index|
+        value = values[index]
         options[:style] = style.is_a?(Array) ? style[index] : style if style
         options[:type] = types.is_a?(Array) ? types[index] : types if types
         options[:formula_value] = formula_values[index] if formula_values.is_a?(Array)

--- a/test/benchmark.rb
+++ b/test/benchmark.rb
@@ -3,6 +3,10 @@ $:.unshift "#{File.dirname(__FILE__)}/../lib"
 require 'axlsx'
 require 'csv'
 require 'benchmark'
+
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
 Axlsx::trust_input = true
 row = []
 input = (32..126).to_a.pack('U*').chars.to_a
@@ -12,6 +16,7 @@ Benchmark.bmbm(30) do |x|
 
   x.report('axlsx_noautowidth') {
     p = Axlsx::Package.new
+    p.use_autowidth = false
     p.workbook do |wb|
       wb.add_worksheet do |sheet|
         times.times do
@@ -19,7 +24,6 @@ Benchmark.bmbm(30) do |x|
         end
       end
     end
-    p.use_autowidth = false
     p.serialize("example_noautowidth.xlsx")
   }
 
@@ -69,4 +73,5 @@ Benchmark.bmbm(30) do |x|
     end
   }
 end
+
 File.delete("example.csv", "example_streamed.xlsx", "example_shared.xlsx", "example_autowidth.xlsx", "example_noautowidth.xlsx")


### PR DESCRIPTION
* In simple cases `DataTypeValidator.validate` is slower then `v.is_a?(ClassName)`
* `%{< ... }` is faster then `str << ('<c r="' << ...)`
* `values.size.times do |index|` is faster then `values.each_with_index do |value, index|`

Overall improvement is small, but for each specific method about 50% faster when compare with `benchmark-ips`