### PR TITLE
Remove the default creator

### DIFF
--- a/lib/axlsx/doc_props/core.rb
+++ b/lib/axlsx/doc_props/core.rb
@@ -10,11 +10,11 @@ module Axlsx
     # @option options [String] creator
     # @option options [Time] created
     def initialize(options={})
-      @creator = options[:creator] || 'axlsx'
+      @creator = options[:creator]
       @created = options[:created]
     end
 
-    # The author of the document. By default this is 'axlsx'
+    # The author of the document. By default this is nil.
     # @return [String]
     attr_accessor :creator
 
@@ -28,7 +28,7 @@ module Axlsx
       str << ('<cp:coreProperties xmlns:cp="' << CORE_NS << '" xmlns:dc="' << CORE_NS_DC << '" ')
       str << ('xmlns:dcmitype="' << CORE_NS_DCMIT << '" xmlns:dcterms="' << CORE_NS_DCT << '" ')
       str << ('xmlns:xsi="' << CORE_NS_XSI << '">')
-      str << ('<dc:creator>' << self.creator << '</dc:creator>')
+      str << ('<dc:creator>' << (self.creator || '') << '</dc:creator>')
       str << ('<dcterms:created xsi:type="dcterms:W3CDTF">' << (created || Time.now).strftime('%Y-%m-%dT%H:%M:%S') << 'Z</dcterms:created>')
       str << '<cp:revision>0</cp:revision>'
       str << '</cp:coreProperties>'

--- a/test/doc_props/tc_core.rb
+++ b/test/doc_props/tc_core.rb
@@ -31,7 +31,7 @@ class TestCore < Test::Unit::TestCase
   end
 
   def test_populates_default_name
-    assert_equal(@doc.xpath('//dc:creator').text, "axlsx", "Default name not populated")
+    assert_equal(@doc.xpath('//dc:creator').text, "", "Default name populated")
   end
 
   def test_creator_as_option


### PR DESCRIPTION
This removes the default creator 'axlsx' from generated documents,
instead the creator is blank (which is valid) if not specified.

This fixes an information disclosure vulnerability.
