### PR TITLE
Cell name setting fix

### DIFF
--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -341,7 +341,7 @@ module Axlsx
 
     # Creates a defined name in the workbook for this cell.
     def name=(label)
-      row.worksheet.workbook.add_defined_name "#{row.worksheet.name}!#{r_abs}", name: label
+      row.worksheet.workbook.add_defined_name "'#{row.worksheet.name}'!#{r_abs}", name: label
       @name = label
     end
 


### PR DESCRIPTION
If sheet has a space in its name `cell.name = 'my_cell'` doesn't work properly.