### PR TITLE
Enable Windows testing on AppVeyor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,12 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rake', '>= 0.8.7'
+  if RUBY_VERSION.to_i < 2
+    gem 'rake', '>= 0.8.7', '< 11'
+    gem 'json', '< 2'
+  else
+    gem 'rake'
+  end
   gem 'simplecov'
   gem 'test-unit'
 end
@@ -15,5 +20,5 @@ platforms :rbx do
   gem 'rubysl'
   gem 'rubysl-test-unit'
   gem 'racc'
-  gem 'rubinius-coverage',  '~> 2.0'
+  gem 'rubinius-coverage', '~> 2.0'
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+version: 2.1.0.{build}-{branch}
+
+environment:
+  matrix:
+    - RUBY_VERSION: 23
+    - RUBY_VERSION: 22
+    - RUBY_VERSION: 21
+    - RUBY_VERSION: 200
+    - RUBY_VERSION: 193
+
+install:
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - bundle install
+
+build: off
+
+before_test:
+  - ruby -v
+  - gem -v
+  - bundle -v
+
+test_script:
+  - bundle exec rake


### PR DESCRIPTION
Hi!

Issue #419 mentions Windows testing as a step towards a new release.

This PR adds setup for testing on AppVeyor.  The tests are running on my fork here:

https://ci.appveyor.com/project/donv/axlsx

This PR also includes adjusting the `Gemfile` to work with Ruby 1.9.x.

Slightly ironically, the tests succeed on Ruby 1.9.3 while there are only **two** failing tests for Ruby 2.0+.  I leave fixing the two failing tests for another committer 😄 .

After merging this PR, the build needs to be activated in AppVeyor.  I would be happy to do that, but I would need admin access to this repo to enable commit callback hooks.
