### PR TITLE
set color with Row#color=

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - 2.3
   - rbx
   - rbx-2
   - jruby-19mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ rvm:
   - 2.2
   - 2.3
   - rbx
+  - rbx-2
   - jruby-19mode
   - jruby-9.0.0.0
   - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ rvm:
 matrix:
   allow_failures:
     - rvm: rbx
+    - rvm: rbx-2
     - rvm: ruby-head
     - rvm: jruby-9.0.0.0
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.3
   - rbx
   - jruby-19mode
   - jruby-9.0.0.0
@@ -23,6 +24,7 @@ rvm:
   - jruby-head
 matrix:
   allow_failures:
+    - rvm: rbx
     - rvm: ruby-head
     - rvm: jruby-9.0.0.0
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,41 @@
 language: ruby
-sudo: false
+sudo: required
+dist: trusty
+group: beta
 cache: bundler
 bundler_args: --without profile
-env:
-  - JRUBY_OPTS="-Xcli.debug=true --debug"
+  
 notifications:
   irc: "irc.freenode.org#axlsx"
   email:
     recipients:
       - digital.ipseity@gmail.com
     on_success: always
-rvm:
-  - 1.9.2
-  - 1.9.3
-  - 2.0
-  - 2.1
-  - 2.2
-  - rbx
-  - rbx-2
-  - jruby-19mode
-  - jruby-9.0.0.0
-  - ruby-head
-  - jruby-head
+
 matrix:
-  allow_failures:
-    - rvm: rbx
-    - rvm: rbx-2
+  include:
+    - rvm: 1.9.3
+    - rvm: 2.0
+    - rvm: 2.1
+    - rvm: 2.2
+    - rvm: 2.3.1
+    - rvm: rbx-3
+    - rvm: jruby-19mode
+      env: JRUBY_OPTS="-Xcli.debug=true --debug"
+    - rvm: jruby-9.1.5.0
+      env: JRUBY_OPTS="-Xcli.debug=true --debug"
     - rvm: ruby-head
-    - rvm: jruby-9.0.0.0
     - rvm: jruby-head
+      env: JRUBY_OPTS="-Xcli.debug=true --debug"
+  allow_failures:
+    - rvm: rbx-3
+    - rvm: ruby-head
+    - rvm: jruby-9.1.5.0
+    - rvm: jruby-head
+
+# https://github.com/jruby/jruby/wiki/FAQs#why-is-jruby-so-slow-to-install-via-rvm
+# https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon
+addons:
+  apt:
+    packages:
+    - haveged

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,12 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rake', '>= 0.8.7'
+  if RUBY_VERSION.to_i < 2
+    gem 'rake', '>= 0.8.7', '< 11'
+    gem 'json', '< 2'
+  else
+    gem 'rake'
+  end
   gem 'simplecov'
   gem 'test-unit'
 end
@@ -15,5 +20,5 @@ platforms :rbx do
   gem 'rubysl'
   gem 'rubysl-test-unit'
   gem 'racc'
-  gem 'rubinius-coverage',  '~> 2.0'
+  gem 'rubinius-coverage', '~> 2.0'
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Axlsx: Office Open XML Spreadsheet Generation
 ====================================
-[![Build Status](https://secure.travis-ci.org/randym/axlsx.png?branch=master)](http://travis-ci.org/randym/axlsx/)
+[![Build Status](https://secure.travis-ci.org/randym/axlsx.svg?branch=master)](http://travis-ci.org/randym/axlsx/)
 
 If you are using axlsx for commercial purposes, or just want to show your
 appreciation for the gem, please don't hesitate to make a donation.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+version: 2.1.0.{build}-{branch}
+
+environment:
+  matrix:
+    - RUBY_VERSION: 23
+    - RUBY_VERSION: 22
+    - RUBY_VERSION: 21
+    - RUBY_VERSION: 200
+    - RUBY_VERSION: 193
+
+install:
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - bundle install
+
+build: off
+
+before_test:
+  - ruby -v
+  - gem -v
+  - bundle -v
+
+test_script:
+  - bundle exec rake

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -66,7 +66,7 @@ module Axlsx
                      :vertAlign, :sz, :color, :scheme].freeze
 
     CELL_TYPES = [:date, :time, :float, :integer, :richtext,
-                  :string, :boolean, :iso_8601].freeze
+                  :string, :boolean, :iso_8601, :text].freeze
 
     # The index of the cellXfs item to be applied to this cell.
     # @return [Integer]
@@ -123,7 +123,7 @@ module Axlsx
 
     # Indicates if the cell is good for shared string table
     def plain_string?
-      type == :string &&         # String typed
+      (type == :string || type == :text) &&         # String typed
         !is_text_run? &&          # No inline styles
         !@value.nil? &&           # Not nil
         !@value.empty? &&         # Not empty
@@ -368,7 +368,7 @@ module Axlsx
     # TODO find a better way to do this as it accounts for 30% of
     # processing time in benchmarking...
     def clean_value
-      if type == :string && !Axlsx::trust_input
+      if (type == :string || type == :text) && !Axlsx::trust_input
         Axlsx::sanitize(::CGI.escapeHTML(@value.to_s))
       else
         @value.to_s

--- a/lib/axlsx/workbook/worksheet/cell_serializer.rb
+++ b/lib/axlsx/workbook/worksheet/cell_serializer.rb
@@ -14,7 +14,7 @@ module Axlsx
         method = cell.type
         self.send(method, cell, str)
         str << '</c>'
-      end 
+      end
 
       # builds an xml text run based on this cells attributes.
       # @param [String] str The string instance this run will be concated to.
@@ -22,7 +22,7 @@ module Axlsx
       def run_xml_string(cell, str = '')
         if cell.is_text_run?
           valid = RichTextRun::INLINE_STYLES - [:value, :type]
-          data = Hash[cell.instance_values.map{ |k, v| [k.to_sym, v] }] 
+          data = Hash[cell.instance_values.map{ |k, v| [k.to_sym, v] }]
           data = data.select { |key, value| valid.include?(key) && !value.nil? }
           RichText.new(cell.value.to_s, data).to_xml_string(str)
         elsif cell.contains_rich_text?
@@ -124,12 +124,24 @@ module Axlsx
           inline_string_serialization cell, str
         end
       end
-      
+
       # Serializes cells that are of the type richtext
       # @param [Cell] cell The cell that is being serialized
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
       def richtext(cell, str)
+        if cell.ssti.nil?
+          inline_string_serialization cell, str
+        else
+          value_serialization 's', cell.ssti, str
+        end
+      end
+
+      # Serializes cells that are of the type text
+      # @param [Cell] cell The cell that is being serialized
+      # @param [String] str The string the serialized content will be appended to.
+      # @return [String]
+      def text(cell, str)
         if cell.ssti.nil?
           inline_string_serialization cell, str
         else

--- a/lib/axlsx/workbook/worksheet/merged_cells.rb
+++ b/lib/axlsx/workbook/worksheet/merged_cells.rb
@@ -19,6 +19,8 @@ module Axlsx
                  cells
                elsif cells.is_a?(Array)
                  Axlsx::cell_range(cells, false)
+               elsif cells.is_a?(Row)
+                 Axlsx::cell_range(cells, false)
                end
     end
 

--- a/lib/axlsx/workbook/worksheet/row.rb
+++ b/lib/axlsx/workbook/worksheet/row.rb
@@ -103,6 +103,13 @@ module Axlsx
       c
     end
 
+    # sets the color for every cell in this row
+    def color=(color)
+      each_with_index do | cell, index |
+        cell.color = color.is_a?(Array) ? color[index] : color
+      end
+    end
+
     # sets the style for every cell in this row
     def style=(style)
       each_with_index do | cell, index |

--- a/test/tc_axlsx.rb
+++ b/test/tc_axlsx.rb
@@ -45,6 +45,16 @@ class TestAxlsx < Test::Unit::TestCase
     assert_equal(Axlsx.cell_range([c2, c1], true), "'Sheet &lt;''&gt;&quot; 1'!$A$1:$B$1")
   end
 
+  def test_cell_range_row
+    p = Axlsx::Package.new
+    ws = p.workbook.add_worksheet
+    row = ws.add_row
+    c1 = row.add_cell
+    c2 = row.add_cell
+    c3 = row.add_cell
+    assert_equal("A1:C1", Axlsx.cell_range(row, false))
+  end
+
   def test_name_to_indices
     setup_wide
     @wide_test_points.each do |key, value|

--- a/test/tc_axlsx.rb
+++ b/test/tc_axlsx.rb
@@ -49,9 +49,9 @@ class TestAxlsx < Test::Unit::TestCase
     p = Axlsx::Package.new
     ws = p.workbook.add_worksheet
     row = ws.add_row
-    c1 = row.add_cell
-    c2 = row.add_cell
-    c3 = row.add_cell
+    row.add_cell
+    row.add_cell
+    row.add_cell
     assert_equal("A1:C1", Axlsx.cell_range(row, false))
   end
 

--- a/test/workbook/worksheet/tc_cell.rb
+++ b/test/workbook/worksheet/tc_cell.rb
@@ -238,7 +238,7 @@ class TestCell < Test::Unit::TestCase
     @c.merge @row.cells.last
     assert_equal(@c.row.worksheet.send(:merged_cells).last, "A1:C1")
   end
-  
+
   def test_reverse_merge_with_cell
     @c.row.add_cell 2
     @c.row.add_cell 3
@@ -284,7 +284,7 @@ class TestCell < Test::Unit::TestCase
     c_xml = Nokogiri::XML(@c.to_xml_string(1,1))
     assert_equal(c_xml.xpath("/c[@s=1]").size, 1)
   end
-  
+
   def test_to_xml_string_with_run
     # Actually quite a number of similar run styles
     # but the processing should be the same
@@ -319,6 +319,21 @@ class TestCell < Test::Unit::TestCase
     assert(doc.xpath("//f[@ref='A1']"))
   end
 
+  def test_to_xml_string_text_formula
+    p = Axlsx::Package.new
+    ws = p.workbook.add_worksheet do |sheet|
+      sheet.add_row ["=1+1", "-1+1"], type: :text
+    end
+    doc = Nokogiri::XML(ws.to_xml_string)
+    doc.remove_namespaces!
+
+    assert(doc.xpath("//f[text()='1+1']").empty?)
+    assert(doc.xpath("//t[text()='=1+1']").any?)
+
+    assert(doc.xpath("//f[text()='1+1']").empty?)
+    assert(doc.xpath("//t[text()='-1+1']").any?)
+  end
+
   def test_font_size_with_custom_style_and_no_sz
     @c.style = @c.row.worksheet.workbook.styles.add_style :bg_color => 'FF00FF'
     sz = @c.send(:font_size)
@@ -335,17 +350,17 @@ class TestCell < Test::Unit::TestCase
     sz = @c.send(:font_size)
     assert_equal(sz, 52)
   end
-  
+
   def test_cell_with_sz
     @c.sz = 25
     assert_equal(25, @c.send(:font_size))
   end
-  
+
   def test_to_xml
     # TODO This could use some much more stringent testing related to the xml content generated!
     @ws.add_row [Time.now, Date.today, true, 1, 1.0, "text", "=sum(A1:A2)", "2013-01-13T13:31:25.123"]
     @ws.rows.last.cells[5].u = true
-    
+
     schema = Nokogiri::XML::Schema(File.open(Axlsx::SML_XSD))
     doc = Nokogiri::XML(@ws.to_xml_string)
     errors = []

--- a/test/workbook/worksheet/tc_cell.rb
+++ b/test/workbook/worksheet/tc_cell.rb
@@ -294,7 +294,7 @@ class TestCell < Test::Unit::TestCase
     @c.font_name = 'arial'
     @c.color = 'FF0000'
     c_xml = Nokogiri::XML(@c.to_xml_string(1,1))
-    assert(c_xml.xpath("//b"))
+    assert(c_xml.xpath("//b").any?)
   end
 
   def test_to_xml_string_formula
@@ -303,8 +303,8 @@ class TestCell < Test::Unit::TestCase
       sheet.add_row ["=IF(2+2=4,4,5)"]
     end
     doc = Nokogiri::XML(ws.to_xml_string)
-    assert(doc.xpath("//f[@text()='IF(2+2=4,4,5)']"))
-
+    doc.remove_namespaces!
+    assert(doc.xpath("//f[text()='IF(2+2=4,4,5)']").any?)
   end
 
   def test_to_xml_string_array_formula
@@ -314,9 +314,9 @@ class TestCell < Test::Unit::TestCase
     end
     doc = Nokogiri::XML(ws.to_xml_string)
     doc.remove_namespaces!
-    assert(doc.xpath("//f[text()='SUM(C2:C11*D2:D11)']"))
-    assert(doc.xpath("//f[@t='array']"))
-    assert(doc.xpath("//f[@ref='A1']"))
+    assert(doc.xpath("//f[text()='SUM(C2:C11*D2:D11)']").any?)
+    assert(doc.xpath("//f[@t='array']").any?)
+    assert(doc.xpath("//f[@ref='A1']").any?)
   end
 
   def test_to_xml_string_text_formula

--- a/test/workbook/worksheet/tc_row.rb
+++ b/test/workbook/worksheet/tc_row.rb
@@ -27,6 +27,11 @@ class TestRow < Test::Unit::TestCase
     r.cells.each { |c| assert_equal(c.style,1) }
   end
 
+  def test_color
+    r = @ws.add_row([1,2,3,4,5])
+    r.color = "FF00FF00"
+    r.cells.each { |c| assert_equal(c.color.rgb, "FF00FF00") }
+  end
 
   def test_index
     assert_equal(@row.row_index, @row.worksheet.rows.index(@row))

--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -323,6 +323,13 @@ class TestWorksheet < Test::Unit::TestCase
     assert_equal(doc.xpath('//xmlns:worksheet/xmlns:mergeCells/xmlns:mergeCell[@ref="E1:F1"]').size, 1)
   end
 
+  def test_to_xml_string_merge_cells_row
+    row = @ws.add_row [1, "two"]
+    @ws.merge_cells row
+    doc = Nokogiri::XML(@ws.to_xml_string)
+    assert_equal(doc.xpath('//xmlns:worksheet/xmlns:mergeCells/xmlns:mergeCell[@ref="A1:B1"]').size, 1)
+  end
+
   def test_to_xml_string_row_breaks
   @ws.add_page_break("A1")
     doc = Nokogiri::XML(@ws.to_xml_string)


### PR DESCRIPTION
Hi 
I think it's convenient if we can set color of row at once.

With this method, we can emphasize special row without knowing a bit complex style option.

Something like .... 

```
  p.workbook.add_worksheet(:name => "Table") do |sheet|
    people.each do |person|
      row = sheet.add_row([person.name, person.age])
      row.color="00FFFF00" if person.salary > 100_000_000
    end
  end
```
