### PR TITLE
Fix #472: worksheet name with underscore

### DIFF
--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -27,7 +27,7 @@ module Axlsx
       yield self if block_given?
     end
 
-    serializable_attributes :sheet_id, :name, :state
+    serializable_attributes :sheet_id, :state
 
     # Initalizes page margin, setup and print options
     # @param [Hash] options Options passed in from the initializer
@@ -597,6 +597,7 @@ module Axlsx
       add_autofilter_defined_name_to_workbook
       str << '<sheet '
       serialized_attributes str
+      str << ('name="' << name << '" ')
       str << ('r:id="' << rId << '"></sheet>')
     end
 

--- a/test/workbook/tc_workbook.rb
+++ b/test/workbook/tc_workbook.rb
@@ -136,4 +136,10 @@ class TestWorkbook < Test::Unit::TestCase
     doc = Nokogiri::XML(@wb.to_xml_string)
     assert_equal pivot_table.cache_definition.rId, doc.xpath("//xmlns:pivotCache").first["r:id"]
   end
+  
+  def test_worksheet_name_is_intact_after_serialized_into_xml
+    sheet = @wb.add_worksheet(:name => '_Example')
+    wb_xml = Nokogiri::XML(@wb.to_xml_string)
+    assert_equal sheet.name, wb_xml.xpath('//xmlns:workbook/xmlns:sheets/*[1]/@name').to_s
+  end
 end


### PR DESCRIPTION
Previously, worksheet name was defined as a serializable_attributes that Axlsx automatically camelize by Axlsx.camel .
This cause an unexpected worksheet name convertion.
For instance,
- "Pie_chart" is converted into "Piechart"
- "_example" is converted into "Example"

This patch disables an unexpected worksheet name convertion.
