### PR TITLE
Allow a Row to be passed to merge_cells

### DIFF
--- a/lib/axlsx/workbook/worksheet/merged_cells.rb
+++ b/lib/axlsx/workbook/worksheet/merged_cells.rb
@@ -19,6 +19,8 @@ module Axlsx
                  cells
                elsif cells.is_a?(Array)
                  Axlsx::cell_range(cells, false)
+               elsif cells.is_a?(Row)
+                 Axlsx::cell_range(cells, false)
                end
     end
 

--- a/test/tc_axlsx.rb
+++ b/test/tc_axlsx.rb
@@ -45,6 +45,16 @@ class TestAxlsx < Test::Unit::TestCase
     assert_equal(Axlsx.cell_range([c2, c1], true), "'Sheet &lt;''&gt;&quot; 1'!$A$1:$B$1")
   end
 
+  def test_cell_range_row
+    p = Axlsx::Package.new
+    ws = p.workbook.add_worksheet
+    row = ws.add_row
+    c1 = row.add_cell
+    c2 = row.add_cell
+    c3 = row.add_cell
+    assert_equal("A1:C1", Axlsx.cell_range(row, false))
+  end
+
   def test_name_to_indices
     setup_wide
     @wide_test_points.each do |key, value|

--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -323,6 +323,13 @@ class TestWorksheet < Test::Unit::TestCase
     assert_equal(doc.xpath('//xmlns:worksheet/xmlns:mergeCells/xmlns:mergeCell[@ref="E1:F1"]').size, 1)
   end
 
+  def test_to_xml_string_merge_cells_row
+    row = @ws.add_row [1, "two"]
+    @ws.merge_cells row
+    doc = Nokogiri::XML(@ws.to_xml_string)
+    assert_equal(doc.xpath('//xmlns:worksheet/xmlns:mergeCells/xmlns:mergeCell[@ref="A1:B1"]').size, 1)
+  end
+
   def test_to_xml_string_row_breaks
   @ws.add_page_break("A1")
     doc = Nokogiri::XML(@ws.to_xml_string)


### PR DESCRIPTION
This PR updates `Worksheet.merge_cells` to allow a `Row` to be passed (or `row.cells`). Previously, it was necessary to call `sheet.merge_cells row.cells.to_a`.
