### PR TITLE
README: Use SVG icon for Travis badge [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Axlsx: Office Open XML Spreadsheet Generation
 ====================================
-[![Build Status](https://secure.travis-ci.org/randym/axlsx.png?branch=master)](http://travis-ci.org/randym/axlsx/)
+[![Build Status](https://secure.travis-ci.org/randym/axlsx.svg?branch=master)](http://travis-ci.org/randym/axlsx/)
 
 If you are using axlsx for commercial purposes, or just want to show your
 appreciation for the gem, please don't hesitate to make a donation.


### PR DESCRIPTION
This trivial change uses the shiny SVG build icon badge instead of the slightly-off PNG.

_Thanks for maintaining this project!_