### PR TITLE
Travis: Test on JRuby 9.1.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,30 +2,33 @@ language: ruby
 sudo: false
 cache: bundler
 bundler_args: --without profile
-env:
-  - JRUBY_OPTS="-Xcli.debug=true --debug"
+  
 notifications:
   irc: "irc.freenode.org#axlsx"
   email:
     recipients:
       - digital.ipseity@gmail.com
     on_success: always
-rvm:
-  - 1.9.2
-  - 1.9.3
-  - 2.0
-  - 2.1
-  - 2.2
-  - rbx
-  - rbx-2
-  - jruby-19mode
-  - jruby-9.0.0.0
-  - ruby-head
-  - jruby-head
+
 matrix:
+  include:
+    - rvm: 1.9.2
+    - rvm: 1.9.3
+    - rvm: 2.0
+    - rvm: 2.1
+    - rvm: 2.2
+    - rvm: rbx
+    - rvm: rbx-2
+    - rvm: jruby-19mode
+      env: JRUBY_OPTS="-Xcli.debug=true --debug"
+    - rvm: jruby-9.1.5.0
+      env: JRUBY_OPTS="-Xcli.debug=true --debug"
+    - rvm: ruby-head
+    - rvm: jruby-head
+      env: JRUBY_OPTS="-Xcli.debug=true --debug"
   allow_failures:
     - rvm: rbx
     - rvm: rbx-2
     - rvm: ruby-head
-    - rvm: jruby-9.0.0.0
+    - rvm: jruby-9.1.5.0
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ notifications:
 
 matrix:
   include:
-    - rvm: 1.9.2
     - rvm: 1.9.3
     - rvm: 2.0
     - rvm: 2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
-sudo: false
+sudo: required
+dist: trusty
+group: beta
 cache: bundler
 bundler_args: --without profile
   
@@ -17,8 +19,8 @@ matrix:
     - rvm: 2.0
     - rvm: 2.1
     - rvm: 2.2
-    - rvm: rbx
-    - rvm: rbx-2
+    - rvm: 2.3.1
+    - rvm: rbx-3
     - rvm: jruby-19mode
       env: JRUBY_OPTS="-Xcli.debug=true --debug"
     - rvm: jruby-9.1.5.0
@@ -27,8 +29,14 @@ matrix:
     - rvm: jruby-head
       env: JRUBY_OPTS="-Xcli.debug=true --debug"
   allow_failures:
-    - rvm: rbx
-    - rvm: rbx-2
+    - rvm: rbx-3
     - rvm: ruby-head
     - rvm: jruby-9.1.5.0
     - rvm: jruby-head
+
+# https://github.com/jruby/jruby/wiki/FAQs#why-is-jruby-so-slow-to-install-via-rvm
+# https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon
+addons:
+  apt:
+    packages:
+    - haveged


### PR DESCRIPTION
This PR changes to build against the stable release of JRuby.

I also changed the Travis build matrix to use  rvm/env pairs, to be able to say exactly what to use where.

- @randym Ruby 1.9.2. This version is no longer supported by the Trusty machine that Travis has. Do you still need to build for 1.9.2? Controversial or not, I removed it from the matrix in this PR.