### PR TITLE
fix warning: constant ::Fixnum is deprecated

### DIFF
--- a/lib/axlsx/drawing/pic.rb
+++ b/lib/axlsx/drawing/pic.rb
@@ -53,7 +53,7 @@ module Axlsx
     attr_reader :hyperlink
 
     # Picture opacity
-    # @return [Fixnum]
+    # @return [Integer]
     attr_reader :opacity
 
     # sets or updates a hyperlink for this image.

--- a/lib/axlsx/drawing/scaling.rb
+++ b/lib/axlsx/drawing/scaling.rb
@@ -6,7 +6,7 @@ module Axlsx
     include Axlsx::OptionsParser
 
     # creates a new Scaling object
-    # @option options [Integer, Fixnum] logBase
+    # @option options [Integer] logBase
     # @option options [Symbol] orientation
     # @option options [Float] max
     # @option options [Float] min
@@ -35,7 +35,7 @@ module Axlsx
     attr_reader :min
 
     # @see logBase
-    def logBase=(v) DataTypeValidator.validate "Scaling.logBase", [Integer, Fixnum], v, lambda { |arg| arg >= 2 && arg <= 1000}; @logBase = v; end
+    def logBase=(v) DataTypeValidator.validate "Scaling.logBase", [Integer], v, lambda { |arg| arg >= 2 && arg <= 1000}; @logBase = v; end
     # @see orientation
     def orientation=(v) RestrictionValidator.validate "Scaling.orientation", [:minMax, :maxMin], v; @orientation = v; end
     # @see max

--- a/lib/axlsx/drawing/view_3D.rb
+++ b/lib/axlsx/drawing/view_3D.rb
@@ -86,12 +86,12 @@ module Axlsx
     alias :rAngAx= :r_ang_ax=
 
       # @see perspective
-      def perspective=(v) 
+      def perspective=(v)
         RangeValidator.validate "View3D.perspective", 0, 240, v
         @perspective = v
       end
 
-    # DataTypeValidator.validate "#{self.class}.perspective", [Integer, Fixnum], v, lambda {|arg| arg >= 0 && arg <= 240 }; @perspective = v; end
+    # DataTypeValidator.validate "#{self.class}.perspective", [Integer], v, lambda {|arg| arg >= 0 && arg <= 240 }; @perspective = v; end
 
     # Serializes the object
     # @param [String] str

--- a/lib/axlsx/util/simple_typed_list.rb
+++ b/lib/axlsx/util/simple_typed_list.rb
@@ -147,7 +147,7 @@ module Axlsx
     # determines if the index is protected
     # @param [Integer] index
     def protected? index
-      return false unless locked_at.is_a? Fixnum
+      return false unless locked_at.is_a? Integer
       index < locked_at
     end
 

--- a/lib/axlsx/util/validators.rb
+++ b/lib/axlsx/util/validators.rb
@@ -80,16 +80,16 @@ module Axlsx
   end
   
   UINT_VALIDATOR = lambda { |arg| arg.respond_to?(:>=) && arg >= 0 }
-  
-  # Requires that the value is a Fixnum or Integer and is greater or equal to 0
+
+  # Requires that the value is a Integer and is greater or equal to 0
   # @param [Any] v The value validated
-  # @raise [ArgumentError] raised if the value is not a Fixnum or Integer value greater or equal to 0
+  # @raise [ArgumentError] raised if the value is not a Integer value greater or equal to 0
   # @return [Boolean] true if the data is valid
   def self.validate_unsigned_int(v)
     DataTypeValidator.validate(:unsigned_int, Integer, v, UINT_VALIDATOR)
   end
 
-  # Requires that the value is a Fixnum Integer or Float and is greater or equal to 0
+  # Requires that the value is a Integer or Float and is greater or equal to 0
   # @param [Any] v The value validated
   # @raise [ArgumentError] raised if the value is not a Fixnun, Integer, Float value greater or equal to 0
   # @return [Boolean] true if the data is valid
@@ -104,7 +104,7 @@ module Axlsx
   end
 
   # Requires that the value is a form that can be evaluated as a boolean in an xml document.
-  # The value must be an instance of Fixnum, String, Integer, Symbol, TrueClass or FalseClass and
+  # The value must be an instance of String, Integer, Symbol, TrueClass or FalseClass and
   # it must be one of 0, 1, "true", "false", :true, :false, true, false, "0", or "1"
   # @param [Any] v The value validated
   def self.validate_boolean(v)

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -555,7 +555,7 @@ module Axlsx
     # @example This would set the first and third column widhts but leave the second column in autofit state.
     #      ws.column_widths 7.2, nil, 3
     # @note For updating only a single column it is probably easier to just set the width of the ws.column_info[col_index].width directly
-    # @param [Integer|Float|Fixnum|nil] widths
+    # @param [Integer|Float|nil] widths
     def column_widths(*widths)
       widths.each_with_index do |value, index|
         next if value == nil

--- a/test/stylesheet/tc_styles.rb
+++ b/test/stylesheet/tc_styles.rb
@@ -133,7 +133,7 @@ class TestStyles < Test::Unit::TestCase
       :font_name => "woot font"
     }
     assert_equal(@styles.parse_font_options {}, nil, "noop if no font keys are set")
-    assert_equal(@styles.parse_font_options(:b=>1).class, Fixnum, "return index of font if not :dxf type")
+    assert(@styles.parse_font_options(:b=>1).is_a?(Integer), "return index of font if not :dxf type")
     assert_equal(@styles.parse_font_options(:b=>1, :type => :dxf).class, Axlsx::Font, "return font object if :dxf type")
 
     f = @styles.parse_font_options(options.merge(:type => :dxf))
@@ -147,7 +147,7 @@ class TestStyles < Test::Unit::TestCase
 
   def test_parse_fill_options
     assert_equal(@styles.parse_fill_options {}, nil, "noop if no fill keys are set")
-    assert_equal(@styles.parse_fill_options(:bg_color => "DE").class, Fixnum, "return index of fill if not :dxf type")
+    assert(@styles.parse_fill_options(:bg_color => "DE").is_a?(Integer), "return index of fill if not :dxf type")
     assert_equal(@styles.parse_fill_options(:bg_color => "DE", :type => :dxf).class, Axlsx::Fill, "return fill object if :dxf type")
     f = @styles.parse_fill_options(:bg_color => "DE", :type => :dxf)
     assert(f.fill_type.bgColor.rgb == "FFDEDEDE")

--- a/test/util/tc_simple_typed_list.rb
+++ b/test/util/tc_simple_typed_list.rb
@@ -1,7 +1,7 @@
 require 'tc_helper.rb'
 class TestSimpleTypedList < Test::Unit::TestCase
   def setup
-    @list = Axlsx::SimpleTypedList.new Fixnum
+    @list = Axlsx::SimpleTypedList.new Integer
   end
 
   def teardown

--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -483,7 +483,7 @@ class TestWorksheet < Test::Unit::TestCase
     @ws.column_widths nil, 0.5
     assert_equal(@ws.column_info[1].width, 0.5, 'eat my width')
     assert_raise(ArgumentError, 'only accept unsigned ints') { @ws.column_widths 2, 7, -1 }
-    assert_raise(ArgumentError, 'only accept Integer, Float or Fixnum') { @ws.column_widths 2, 7, "-1" }
+    assert_raise(ArgumentError, 'only accept Integer or Float') { @ws.column_widths 2, 7, "-1" }
   end
 
   def test_protect_range


### PR DESCRIPTION
fix Fixnum deprecated warning on Ruby2.4-preview3.
Fixnum was unify into Integer.
https://bugs.ruby-lang.org/issues/12005