### PR TITLE
Bump rubyzip to 1.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :test do
 end
 
 group :profile do
-  gem 'ruby-prof'
+  gem 'ruby-prof', :platforms => :ruby
 end
 
 platforms :rbx do

--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files  = Dir.glob("{test/**/*}")
 
   s.add_runtime_dependency 'nokogiri', '>= 1.6.6'
-  s.add_runtime_dependency 'rubyzip', '~> 1.1.7'
+  s.add_runtime_dependency 'rubyzip', '~> 1.2'
   s.add_runtime_dependency "htmlentities", "~> 4.3.4"
   s.add_runtime_dependency "mimemagic", "~> 0.3"
 


### PR DESCRIPTION
The latest `rubyzip` release has a fix to disable JRuby's ObjectSpace, along with other bug fixes. There doesn't appear to be any major breaking changes:

https://github.com/rubyzip/rubyzip/blob/master/Changelog.md#120

Addresses #468 