### PR TITLE
Fix RubyZip vulnerability [URGENT]

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files  = Dir.glob("{test/**/*}")
 
   s.add_runtime_dependency 'nokogiri', '>= 1.6.6'
-  s.add_runtime_dependency 'rubyzip', '~> 1.2'
+  s.add_runtime_dependency 'rubyzip', '>= 1.2.1'
   s.add_runtime_dependency "htmlentities", "~> 4.3.4"
   s.add_runtime_dependency "mimemagic", "~> 0.3"
 


### PR DESCRIPTION
According to [NIST CVE-2017-5946](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-5946), RubyZip versions less than 1.2.1 have a directory traversal vulnerability so I changed the gemspec to force RubyZip version 1.2.1 to prevent this vulnerability. 