### PR TITLE
Tighten rubyzip dependency version requirement to follow semver

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files  = Dir.glob("{test/**/*}")
 
   s.add_runtime_dependency 'nokogiri', '>= 1.6.6'
-  s.add_runtime_dependency 'rubyzip', '>= 1.2.1'
+  s.add_runtime_dependency 'rubyzip', '~> 1.2', '>= 1.2.1'
   s.add_runtime_dependency "htmlentities", "~> 4.3.4"
   s.add_runtime_dependency "mimemagic", "~> 0.3"
 


### PR DESCRIPTION
For now if `rubyzip` 2.0 will be released, we will happily depend on it and things may broke.

RubyGems advises to use multiple version constraints for this case.
See http://guides.rubygems.org/patterns/#declaring-dependencies

So we will depend on any stable 1.x version that is greater than 1.2.1

This follows up https://github.com/randym/axlsx/pull/507

P.S> Please release a pre2 version on RubyGems