### PR TITLE
Updated nokogiri for CVE-2017-5946

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir.glob("{lib/**/*,examples/**/*.rb,examples/**/*.jpeg}") + %w{ LICENSE README.md Rakefile CHANGELOG.md .yardopts .yardopts_guide }
   s.test_files  = Dir.glob("{test/**/*}")
 
-  s.add_runtime_dependency 'nokogiri', '>= 1.6.6'
+  s.add_runtime_dependency 'nokogiri', '>= 1.7.1'
   s.add_runtime_dependency 'rubyzip', '>= 1.2.1'
   s.add_runtime_dependency "htmlentities", "~> 4.3.4"
   s.add_runtime_dependency "mimemagic", "~> 0.3"

--- a/lib/axlsx/version.rb
+++ b/lib/axlsx/version.rb
@@ -1,5 +1,5 @@
 module Axlsx
-
+  
   # The current version
-  VERSION = "2.1.0.pre"
+  VERSION = "2.1.1.pre"
 end


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5946

This PR updates the version of `nokogiri` to resolve CVE-2017-5946.