### PR TITLE
Add xlsx-validator to travis build matrix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.bundle
+vendor
+ci/Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ unzip
 coverage
 .yardoc
 coverage.data
+vendor
 *.gem
 *.xlsx
 example.csv

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-9.1.8.0
     - rvm: jruby-head
+    - services: docker
 
 # https://github.com/jruby/jruby/wiki/FAQs#why-is-jruby-so-slow-to-install-via-rvm
 # https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-head
       env: JRUBY_OPTS="-Xcli.debug=true --debug"
+    - services: docker
+      before_install: docker build . -f ci/Dockerfile -t axlsx
+      script: docker run axlsx ci/validate-xlsx-files.sh
   allow_failures:
     - rvm: rbx-3
     - rvm: ruby-head

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,13 @@
+# vim: set ft=Dockerfile
+
+FROM vindvaki/xlsx-validator
+
+RUN apt-get install -y build-essential ruby ruby-dev libxslt-dev libxml2-dev zlib1g-dev
+RUN gem install bundler
+ADD Gemfile* axlsx.gemspec /app/axlsx/
+WORKDIR /app/axlsx/
+ADD lib/axlsx/version.rb lib/axlsx/version.rb
+RUN bundle install
+ADD . .
+
+ADD ci/validate-xlsx-files.sh .

--- a/ci/validate-xlsx-files.sh
+++ b/ci/validate-xlsx-files.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+bundle exec ruby examples/example.rb
+xlsx-validator *.xlsx


### PR DESCRIPTION
As promised in https://github.com/randym/axlsx/issues/501#issuecomment-290926362

This adds a run of [xlsx-validator](https://github.com/vindvaki/xlsx-validator) on the files generated by `examples/example.rb` to the travis build matrix. You can see it in action on [travis for my fork](https://travis-ci.org/vindvaki/axlsx)

These same steps can be used to run the validator locally as long as you have docker installed.