### PR TITLE
Sort archive entries for correct MIME detection

### DIFF
--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 module Axlsx
   # Package is responsible for managing all the bits and peices that Open Office XML requires to make a valid
   # xlsx document including valdation and serialization.
@@ -253,7 +253,9 @@ module Axlsx
         parts << {:entry => "xl/#{sheet.rels_pn}", :doc => sheet.relationships, :schema => RELS_XSD}
         parts << {:entry => "xl/#{sheet.pn}", :doc => sheet, :schema => SML_XSD}
       end
-      parts
+
+      # Sort parts for correct MIME detection
+      parts.sort_by { |part| part[:entry] }
     end
 
     # Performs xsd validation for a signle document

--- a/test/tc_helper.rb
+++ b/test/tc_helper.rb
@@ -8,3 +8,5 @@ end
 require 'test/unit'
 require "timecop"
 require "axlsx.rb"
+# MIME detection for Microsoft Office 2007+ formats
+require 'mimemagic/overlay'

--- a/test/tc_package.rb
+++ b/test/tc_package.rb
@@ -154,6 +154,11 @@ class TestPackage < Test::Unit::TestCase
     assert package_1.to_stream.string == package_2.to_stream.string, "zip files are not identical"
   end
 
+  def test_serialization_creates_files_with_excel_mime_type
+    assert_equal(MimeMagic.by_magic(@package.to_stream).type,
+                 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+  end
+
   def test_validation
     assert_equal(@package.validate.size, 0, @package.validate)
     Axlsx::Workbook.send(:class_variable_set, :@@date1904, 9900)


### PR DESCRIPTION
Need this patch to sort archive entries to match the file format generated by MS Excel.  Without it, files generated by `axlsx` would have `application/zip` mime type.

```
MimeMagic.by_magic(File.open('tmp/foo.xlsx')).type 
=> "application/zip"
```

```
MimeMagic.by_magic(File.open('tmp/ms.xlsx')).type
=> "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
```