### PR TITLE
CI against latest rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ notifications:
 matrix:
   include:
     - rvm: 2.1
-    - rvm: 2.2.7
-    - rvm: 2.3.4
+    - rvm: 2.2.8
+    - rvm: 2.3.5
     - rvm: 2.0.0
-    - rvm: 2.4.1
+    - rvm: 2.4.2
     - rvm: rbx-3
     - rvm: jruby-19mode
       env: JRUBY_OPTS="-Xcli.debug=true --debug"


### PR DESCRIPTION
 Update Travis CI to use latest Rubies.

https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-2-8-released/
https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-3-5-released/
https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-4-2-released/