### PR TITLE
Axlsx.sanitize() uses delete() vs. delete!() for frozen strings

### DIFF
--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -136,10 +136,10 @@ module Axlsx
   # @param [String] str The string to process
   # @return [String]
   def self.sanitize(str)
-    str.delete!(CONTROL_CHARS)
+    str.delete(CONTROL_CHARS)
     str
   end
-  
+
   # If value is boolean return 1 or 0
   # else return the value
   # @param [Object] value The value to process

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -136,8 +136,12 @@ module Axlsx
   # @param [String] str The string to process
   # @return [String]
   def self.sanitize(str)
-    str.delete(CONTROL_CHARS)
-    str
+    if str.frozen?
+      str.delete(CONTROL_CHARS)
+    else
+      str.delete!(CONTROL_CHARS)
+      str
+    end
   end
 
   # If value is boolean return 1 or 0

--- a/test/tc_axlsx.rb
+++ b/test/tc_axlsx.rb
@@ -79,4 +79,25 @@ class TestAxlsx < Test::Unit::TestCase
     assert_equal([['Z5', 'AA5', 'AB5'], ['Z6', 'AA6', 'AB6']], Axlsx::range_to_a('Z5:AB6'))
   end
 
+  def test_sanitize_frozen_control_strippped
+    needs_sanitize = "legit\x08".freeze # Backspace control char
+
+    assert_equal(Axlsx.sanitize(needs_sanitize), 'legit', 'should strip control chars')
+  end
+
+  def test_sanitize_unfrozen_control_strippped
+    needs_sanitize = "legit\x08" # Backspace control char
+    sanitized_str = Axlsx.sanitize(needs_sanitize)
+
+    assert_equal(sanitized_str,           'legit',                  'should strip control chars')
+    assert_equal(sanitized_str.object_id, sanitized_str.object_id,  'should preserve object')
+  end
+
+  def test_sanitize_unfrozen_no_sanitize
+    legit_str = 'legit'
+    sanitized_str = Axlsx.sanitize(legit_str)
+
+    assert_equal(sanitized_str,           legit_str,            'should preserve value')
+    assert_equal(sanitized_str.object_id, legit_str.object_id,  'should preserve object')
+  end
 end


### PR DESCRIPTION
Whenever a frozen string is passed as an input to any sanitized value, we are modifying it in place which raised a RuntimeError if that string is frozen (as you might expect constants like header or workbook names to be).  Use the safer delete() method which creates a new, modified copy of the string.