### PR TITLE
Travis: jruby-9.2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ matrix:
     - rvm: 2.4.2
     - rvm: rbx-3
     - rvm: jruby-19mode
-    - rvm: jruby-9.1.17.0
+    - rvm: jruby-9.2.0.0
     - rvm: ruby-head
     - rvm: jruby-head
   allow_failures:
     - rvm: rbx-3
     - rvm: ruby-head
-    - rvm: jruby-9.1.17.0
+    - rvm: jruby-9.2.0.0
     - rvm: jruby-head
 
 env:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/05/24/jruby-9-2-0-0.html