### PR TITLE
Address security vulnerability in rubyzip dependency

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files  = Dir.glob("{test/**/*}")
 
   s.add_runtime_dependency 'nokogiri', '~> 1.8', '>= 1.8.2'
-  s.add_runtime_dependency 'rubyzip','~> 1.2', '>= 1.2.1'
+  s.add_runtime_dependency 'rubyzip','~> 1.2', '>= 1.2.2'
   s.add_runtime_dependency "htmlentities", "~> 4.3", '>= 4.3.4'
   s.add_runtime_dependency "mimemagic", '~> 0.3'
 


### PR DESCRIPTION
The rubyzip gem version 1.2.1 contains a security vulnerability allowing
absolute path traversal.  More details can be found here:

https://github.com/rubyzip/rubyzip/issues/369

This change addresses the issue by specifying a rubyzip version greater
than or equal to 1.2.2.

Solves issue #599