### PR TITLE
Allow RichText to be initialized with an array of hashes

### DIFF
--- a/lib/axlsx/workbook/worksheet/rich_text.rb
+++ b/lib/axlsx/workbook/worksheet/rich_text.rb
@@ -5,11 +5,21 @@ module Axlsx
 
     # creates a new RichText collection
     # @param [String] text -optional The text to use in creating the first RichTextRun
+    # @param [Array] text -optional An array of Hashes to use to create multiple RichTextRuns
     # @param [Object] options -optional The options to use in creating the first RichTextRun
     # @yield [RichText] self
     def initialize(text = nil, options={})
       super(RichTextRun)
-      add_run(text, options) unless text.nil?
+      unless text.nil?
+        if text.is_a?(Array)
+          text.each do |run_hash|
+            add_run(run_hash[:text], run_hash[:options] || {})
+          end
+        else
+          add_run(text, options)
+        end
+      end
+
       yield self if block_given?
     end
 

--- a/test/workbook/worksheet/tc_rich_text.rb
+++ b/test/workbook/worksheet/tc_rich_text.rb
@@ -24,6 +24,16 @@ class RichText < Test::Unit::TestCase
     row = @ws.add_row [rt_direct, rt_indirect]
     assert_equal(row[0].to_xml_string(0,0), row[1].to_xml_string(0,0))
   end
+
+  def test_initialize_with_array_of_hashes
+    assert_equal(@c.value, @rt)
+    rt_from_array = Axlsx::RichText.new([{ :text => 'hi', :options => { :i => true }}, { :text => 'hi', :options => { :i => true }}])
+    assert_equal(rt_from_array.runs.length, 2)
+    rt_direct_and_indirect = Axlsx::RichText.new('hi', :i => true)
+    rt_direct_and_indirect.add_run('hi', :i => true)
+    row = @ws.add_row [rt_from_array, rt_direct_and_indirect]
+    assert_equal(row[0].to_xml_string(0,0), row[1].to_xml_string(0,0))
+  end
   
   def test_textruns
     runs = @rt.runs


### PR DESCRIPTION
I am proposing a tweak to the initialization method of the `RichText` class. This tweak will allow users to initialize a `RichText` object with multiple runs rather than just a single run.

```ruby
runs  = [{ text: 'First', options: { b: true } }, { text: ', Second' }, { text: ', ' }, { text: 'Third', options: { i: true } }]
rt = RichText.new(runs)
```
`rt` would be a cell with the following styling: **First**, Second, _Third_
