### PR TITLE
Remove rdoc from gemspec

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.date        = Time.now.strftime('%Y-%m-%d')
   s.summary     = "Excel OOXML (xlsx) with charts, styles, images and autowidth columns."
-  s.has_rdoc    = 'axlsx'
   s.license     = 'MIT'
   s.description = <<-eof
     xlsx spreadsheet generation with charts, images, automated column width, customizable styles and full schema validation. Axlsx helps you create beautiful Office Open XML Spreadsheet documents ( Excel, Google Spreadsheets, Numbers, LibreOffice) without having to understand the entire ECMA specification. Check out the README for some examples of how easy it is. Best of all, you can validate your xlsx file before serialization so you know for sure that anything generated is going to load on your client's machine.

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -100,11 +100,13 @@ module Axlsx
     #   File.open('example_streamed.xlsx', 'w') { |f| f.write(s.read) }
     def serialize(output, confirm_valid=false)
       return false unless !confirm_valid || self.validate.empty?
-      Relationship.clear_cached_instances
+      Relationship.initialize_cached_instances
       Zip::OutputStream.open(output) do |zip|
         write_parts(zip)
       end
       true
+    ensure
+      Relationship.clear_cached_instances
     end
 
 
@@ -113,11 +115,13 @@ module Axlsx
     # @return [StringIO|Boolean] False if confirm_valid and validation errors exist. rewound string IO if not.
     def to_stream(confirm_valid=false)
       return false unless !confirm_valid || self.validate.empty?
-      Relationship.clear_cached_instances
+      Relationship.initialize_cached_instances
       zip = write_parts(Zip::OutputStream.new(StringIO.new, true))
       stream = zip.close_buffer
       stream.rewind
       stream
+    ensure
+      Relationship.clear_cached_instances
     end
 
     # Encrypt the package into a CFB using the password provided

--- a/lib/axlsx/rels/relationship.rb
+++ b/lib/axlsx/rels/relationship.rb
@@ -8,10 +8,10 @@ module Axlsx
       # Keeps track of all instances of this class.
       # @return [Array]
       def instances
-        @instances ||= []
+        Thread.current[:axlsx_relationship_cached_instances] ||= []
       end
-      
-      # Clear cached instances.
+
+      # Initialize cached instances.
       # 
       # This should be called before serializing a package (see {Package#serialize} and
       # {Package#to_stream}) to make sure that serialization is idempotent (i.e. 
@@ -20,8 +20,16 @@ module Axlsx
       # 
       # Also, calling this avoids memory leaks (cached instances lingering around 
       # forever). 
+      def initialize_cached_instances
+        Thread.current[:axlsx_relationship_cached_instances] = []
+      end
+
+      # Clear cached instances.
+      #
+      # This should be called after serializing a package (see {Package#serialize} and
+      # {Package#to_stream}) to free the memory allocated for cache.
       def clear_cached_instances
-        @instances = []
+        Thread.current[:axlsx_relationship_cached_instances] = nil
       end
       
       # Generate and return a unique id (eg. `rId123`) Used for setting {#Id}. 
@@ -30,7 +38,7 @@ module Axlsx
       # {clear_cached_instances} will automatically reset the generated ids, too.
       # @return [String]
       def next_free_id
-        "rId#{@instances.size + 1}"
+        "rId#{instances.size + 1}"
       end
     end
 

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -264,7 +264,7 @@ module Axlsx
       @header_footer
     end
 
-    # convinience method to access all cells in this worksheet
+    # convenience method to access all cells in this worksheet
     # @return [Array] cells
     def cells
       rows.flatten


### PR DESCRIPTION
because Bundler says:
`NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.`