### PR TITLE
Memory optimization (~30% less)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path(File.dirname(__FILE__) + '/lib/axlsx/version.rb')
 
 task :build => :gendoc do

--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../lib/axlsx/version', __FILE__)
 
 Gem::Specification.new do |s|

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 require 'htmlentities'
 require 'axlsx/version.rb'
 require 'mimemagic'
@@ -90,7 +91,7 @@ module Axlsx
   # @note This follows the standard spreadsheet convention of naming columns A to Z, followed by AA to AZ etc.
   # @return [String]
   def self.col_ref(index)
-    chars = ''
+    chars = String.new
     while index >= 26 do
       index, char = index.divmod(26)
       chars.prepend((char + 65).chr)

--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -114,8 +114,8 @@ module Axlsx
     range.match(/^(\w+?\d+)\:(\w+?\d+)$/)
     start_col, start_row = name_to_indices($1)
     end_col,   end_row   = name_to_indices($2)
-    (start_row..end_row).to_a.map do |row_num|
-      (start_col..end_col).to_a.map do |col_num|
+    (start_row..end_row).map do |row_num|
+      (start_col..end_col).map do |col_num|
         cell_r(col_num, row_num)
       end
     end
@@ -125,9 +125,10 @@ module Axlsx
   # @param [String] s The snake case string to camelize
   # @return [String]
   def self.camel(s="", all_caps = true)
-    s = s.to_s
-    s = s.capitalize if all_caps
-    s.gsub(/_(.)/){ $1.upcase }
+    s_copy = s.to_s.dup
+    s_copy = s_copy.capitalize! if all_caps
+    s_copy.gsub!(/_(.)/){ $1.upcase }
+    s_copy
   end
 
   # returns the provided string with all invalid control charaters

--- a/lib/axlsx/content_type/abstract_content_type.rb
+++ b/lib/axlsx/content_type/abstract_content_type.rb
@@ -23,8 +23,8 @@ module Axlsx
 
     # Serialize the contenty type to xml
     def to_xml_string(node_name = '', str = '')
-      str << "<#{node_name} "
-      str << instance_values.map { |key, value| Axlsx::camel(key) << '="' << value.to_s << '"' }.join(' ')
+      str << "<#{node_name}"
+      instance_values.each { |key, value| str << " #{Axlsx::camel(key)}=\"#{value}\"" }
       str << '/>'
     end
 

--- a/lib/axlsx/content_type/abstract_content_type.rb
+++ b/lib/axlsx/content_type/abstract_content_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # This class extracts the common parts from Default and Override
@@ -22,7 +23,7 @@ module Axlsx
     alias :ContentType= :content_type=
 
     # Serialize the contenty type to xml
-    def to_xml_string(node_name = '', str = '')
+    def to_xml_string(node_name = '', str = String.new)
       str << "<#{node_name}"
       instance_values.each { |key, value| str << " #{Axlsx::camel(key)}=\"#{value}\"" }
       str << '/>'

--- a/lib/axlsx/content_type/content_type.rb
+++ b/lib/axlsx/content_type/content_type.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   require 'axlsx/content_type/abstract_content_type.rb'
   require 'axlsx/content_type/default.rb'
@@ -14,7 +15,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<?xml version="1.0" encoding="UTF-8"?>'\
              "<Types xmlns=\"#{XML_NS_T}\">"
       each { |type| type.to_xml_string(str) }

--- a/lib/axlsx/content_type/content_type.rb
+++ b/lib/axlsx/content_type/content_type.rb
@@ -15,8 +15,8 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << ('<Types xmlns="' << XML_NS_T << '">')
+      str << '<?xml version="1.0" encoding="UTF-8"?>'\
+             "<Types xmlns=\"#{XML_NS_T}\">"
       each { |type| type.to_xml_string(str) }
       str << '</Types>'
     end

--- a/lib/axlsx/content_type/default.rb
+++ b/lib/axlsx/content_type/default.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # An default content part. These parts are automatically created by for you based on the content of your package.
@@ -17,7 +18,7 @@ module Axlsx
     alias :Extension= :extension=
 
     # Serializes this object to xml
-    def to_xml_string(str ='')
+    def to_xml_string(str = String.new)
       super(NODE_NAME, str)
     end
   end

--- a/lib/axlsx/content_type/override.rb
+++ b/lib/axlsx/content_type/override.rb
@@ -1,5 +1,6 @@
 
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # An override content part. These parts are automatically created by for you based on the content of your package.
@@ -18,7 +19,7 @@ module Axlsx
     alias :PartName= :part_name=
 
     # Serializes this object to xml
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       super(NODE_NAME, str)
     end
   end

--- a/lib/axlsx/doc_props/app.rb
+++ b/lib/axlsx/doc_props/app.rb
@@ -221,8 +221,8 @@ module Axlsx
     # Serialize the app.xml document
     # @return [String]
     def to_xml_string(str = '')
-      str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << ('<Properties xmlns="' << APP_NS << '" xmlns:vt="' << APP_NS_VT << '">')
+      str << '<?xml version="1.0" encoding="UTF-8"?>'\
+             "<Properties xmlns=\"#{APP_NS}\" xmlns:vt=\"#{APP_NS_VT}\">"
       instance_values.each do |key, value|
         node_name = Axlsx.camel(key)
         str << "<#{node_name}>#{value}</#{node_name}>"

--- a/lib/axlsx/doc_props/app.rb
+++ b/lib/axlsx/doc_props/app.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # App represents the app.xml document. The attributes for this object are primarily managed by the application the end user uses to edit the document. None of the attributes are required to serialize a valid xlsx object.
@@ -220,7 +221,7 @@ module Axlsx
 
     # Serialize the app.xml document
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<?xml version="1.0" encoding="UTF-8"?>'\
              "<Properties xmlns=\"#{APP_NS}\" xmlns:vt=\"#{APP_NS_VT}\">"
       instance_values.each do |key, value|

--- a/lib/axlsx/doc_props/core.rb
+++ b/lib/axlsx/doc_props/core.rb
@@ -5,7 +5,7 @@ module Axlsx
   # @note Packages manage their own core object.
   # @see Package#core
   class Core
- 
+
     # Creates a new Core object.
     # @option options [String] creator
     # @option options [Time] created
@@ -24,14 +24,16 @@ module Axlsx
     # serializes the core.xml document
     # @return [String]
     def to_xml_string(str = '')
-      str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << ('<cp:coreProperties xmlns:cp="' << CORE_NS << '" xmlns:dc="' << CORE_NS_DC << '" ')
-      str << ('xmlns:dcmitype="' << CORE_NS_DCMIT << '" xmlns:dcterms="' << CORE_NS_DCT << '" ')
-      str << ('xmlns:xsi="' << CORE_NS_XSI << '">')
-      str << ('<dc:creator>' << self.creator << '</dc:creator>')
-      str << ('<dcterms:created xsi:type="dcterms:W3CDTF">' << (created || Time.now).strftime('%Y-%m-%dT%H:%M:%S') << 'Z</dcterms:created>')
-      str << '<cp:revision>0</cp:revision>'
-      str << '</cp:coreProperties>'
+      str << <<-XML.gsub!("\n", '')
+<?xml version="1.0" encoding="UTF-8"?>
+<cp:coreProperties xmlns:cp="#{CORE_NS}" xmlns:dc="#{CORE_NS_DC}"
+ xmlns:dcmitype="#{CORE_NS_DCMIT}" xmlns:dcterms="#{CORE_NS_DCT}"
+ xmlns:xsi="#{CORE_NS_XSI}">
+<dc:creator>#{self.creator}</dc:creator>
+<dcterms:created xsi:type="dcterms:W3CDTF">#{(created || Time.now).strftime('%Y-%m-%dT%H:%M:%S')}Z</dcterms:created>
+<cp:revision>0</cp:revision>
+</cp:coreProperties>
+XML
     end
 
   end

--- a/lib/axlsx/drawing/area_chart.rb
+++ b/lib/axlsx/drawing/area_chart.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # The AreaChart is a two dimentional line chart (who would have guessed?) that you can add to your worksheet.
@@ -75,7 +76,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       super(str) do
         str << "<c:#{node_name}>"\
                "<c:grouping val=\"#{grouping}\"/>"\

--- a/lib/axlsx/drawing/area_chart.rb
+++ b/lib/axlsx/drawing/area_chart.rb
@@ -77,14 +77,14 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       super(str) do
-        str << ("<c:" << node_name << ">")
-        str << ('<c:grouping val="' << grouping.to_s << '"/>')
-        str << ('<c:varyColors val="' << vary_colors.to_s << '"/>')
+        str << "<c:#{node_name}>"\
+               "<c:grouping val=\"#{grouping}\"/>"\
+               "<c:varyColors val=\"#{vary_colors}\"/>"
         @series.each { |ser| ser.to_xml_string(str) }
         @d_lbls.to_xml_string(str) if @d_lbls
         yield if block_given?
         axes.to_xml_string(str, :ids => true)
-        str << ("</c:" << node_name << ">")
+        str << "</c:#{node_name}>"
         axes.to_xml_string(str)
       end
     end

--- a/lib/axlsx/drawing/area_series.rb
+++ b/lib/axlsx/drawing/area_series.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # A AreaSeries defines the title, data and labels for line charts
   # @note The recommended way to manage series is to use Chart#add_series
@@ -71,7 +72,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       super(str) do
         if color
           str << '<c:spPr><a:solidFill>'\

--- a/lib/axlsx/drawing/area_series.rb
+++ b/lib/axlsx/drawing/area_series.rb
@@ -74,27 +74,27 @@ module Axlsx
     def to_xml_string(str = '')
       super(str) do
         if color
-          str << '<c:spPr><a:solidFill>'
-          str << ('<a:srgbClr val="' << color << '"/>')
-          str << '</a:solidFill>'
-          str << '<a:ln w="28800">'
-          str << '<a:solidFill>'
-          str << ('<a:srgbClr val="' << color << '"/>')
-          str << '</a:solidFill>'
-          str << '</a:ln>'
-          str << '<a:round/>'
-          str << '</c:spPr>'
+          str << '<c:spPr><a:solidFill>'\
+                 "<a:srgbClr val=\"#{color}\"/>"\
+                 '</a:solidFill>'\
+                 '<a:ln w="28800">'\
+                 '<a:solidFill>'\
+                 "<a:srgbClr val=\"#{color}\"/>"\
+                 '</a:solidFill>'\
+                 '</a:ln>'\
+                 '<a:round/>'\
+                 '</c:spPr>'
         end
 
         if !@show_marker
           str << '<c:marker><c:symbol val="none"/></c:marker>'
         elsif @marker_symbol != :default
-          str << '<c:marker><c:symbol val="' + @marker_symbol.to_s + '"/></c:marker>'
+          str << "<c:marker><c:symbol val=\"#{@marker_symbol}\"/></c:marker>"
         end
 
         @labels.to_xml_string(str) unless @labels.nil?
         @data.to_xml_string(str) unless @data.nil?
-        str << ('<c:smooth val="' << ((smooth) ? '1' : '0') << '"/>')
+        str << "<c:smooth val=\"#{smooth ? 1 : 0}\"/>"
       end
     end
 

--- a/lib/axlsx/drawing/ax_data_source.rb
+++ b/lib/axlsx/drawing/ax_data_source.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # An axis data source that can contain referenced or literal strings or numbers

--- a/lib/axlsx/drawing/axes.rb
+++ b/lib/axlsx/drawing/axes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # The Axes class creates and manages axis information and
@@ -28,7 +29,7 @@ module Axlsx
     # @option options ids
     # If the ids option is specified only the axis identifier is
     # serialized. Otherwise, each axis is serialized in full.
-    def to_xml_string(str = '', options = {})
+    def to_xml_string(str = String.new, options = {})
       if options[:ids]
         # CatAxis must come first in the XML (for Microsoft Excel at least)
         sorted = axes.sort_by { |name, axis| axis.kind_of?(CatAxis) ? 0 : 1 }

--- a/lib/axlsx/drawing/axes.rb
+++ b/lib/axlsx/drawing/axes.rb
@@ -1,5 +1,5 @@
 module Axlsx
-  
+
   # The Axes class creates and manages axis information and
   # serialization for charts.
   class Axes
@@ -16,7 +16,7 @@ module Axlsx
     end
 
     # [] provides assiciative access to a specic axis store in an axes
-    # instance. 
+    # instance.
     # @return [Axis]
     def [](name)
       axes.assoc(name)[1]
@@ -27,12 +27,12 @@ module Axlsx
     # @param [Hash] options
     # @option options ids
     # If the ids option is specified only the axis identifier is
-    # serialized. Otherwise, each axis is serialized in full. 
+    # serialized. Otherwise, each axis is serialized in full.
     def to_xml_string(str = '', options = {})
       if options[:ids]
         # CatAxis must come first in the XML (for Microsoft Excel at least)
         sorted = axes.sort_by { |name, axis| axis.kind_of?(CatAxis) ? 0 : 1 }
-        sorted.each { |axis| str << ('<c:axId val="' << axis[1].id.to_s << '"/>') }        
+        sorted.each { |axis| str << "<c:axId val=\"#{axis[1].id}\"/>" }
       else
         axes.each { |axis| axis[1].to_xml_string(str) }
       end

--- a/lib/axlsx/drawing/axis.rb
+++ b/lib/axlsx/drawing/axis.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # the access class defines common properties and values for a chart axis.
@@ -149,7 +150,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << "<c:axId val=\"#{@id}\"/>"
       @scaling.to_xml_string str
       str << "<c:delete val=\"#{@delete}\"/>"\

--- a/lib/axlsx/drawing/axis.rb
+++ b/lib/axlsx/drawing/axis.rb
@@ -83,14 +83,14 @@ module Axlsx
     # the title for the axis. This can be a cell or a fixed string.
     attr_reader :title
 
-    # The color for this axis. This value is used when rendering the axis line in the chart. 
+    # The color for this axis. This value is used when rendering the axis line in the chart.
     # colors should be in 6 character rbg format
     # @return [String] the rbg color assinged.
     # @see color
     def color=(color_rgb)
       @color = color_rgb
     end
-    
+
     # The crossing axis for this axis
     # @param [Axis] axis
     def cross_axis=(axis)
@@ -150,39 +150,39 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << ('<c:axId val="' << @id.to_s << '"/>')
+      str << "<c:axId val=\"#{@id}\"/>"
       @scaling.to_xml_string str
-      str << ('<c:delete val="' << @delete.to_s << '"/>')
-      str << ('<c:axPos val="' << @ax_pos.to_s << '"/>')
-      str << '<c:majorGridlines>'
+      str << "<c:delete val=\"#{@delete}\"/>"\
+             "<c:axPos val=\"#{@ax_pos}\"/>"\
+             '<c:majorGridlines>'
       # TODO shape properties need to be extracted into a class
       if gridlines == false
-        str << '<c:spPr>'
-        str << '<a:ln>'
-        str << '<a:noFill/>'
-        str << '</a:ln>'
-        str << '</c:spPr>'
+        str << '<c:spPr>'\
+               '<a:ln>'\
+               '<a:noFill/>'\
+               '</a:ln>'\
+               '</c:spPr>'
       end
       str << '</c:majorGridlines>'
       @title.to_xml_string(str) unless @title == nil
       # Need to set sourceLinked to 0 if we're setting a format code on this row
       # otherwise it will never take, as it will always prefer the 'General' formatting
       # of the cells themselves
-      str << ('<c:numFmt formatCode="' << @format_code << '" sourceLinked="' << (@format_code.eql?('General') ? '1' : '0') << '"/>')
-      str << '<c:majorTickMark val="none"/>'
-      str << '<c:minorTickMark val="none"/>'
-      str << ('<c:tickLblPos val="' << @tick_lbl_pos.to_s << '"/>')
+      str << "<c:numFmt formatCode=\"#{@format_code}\" sourceLinked=\"#{@format_code.eql?('General') ? 1 : 0}\"/>"\
+             '<c:majorTickMark val="none"/>'\
+             '<c:minorTickMark val="none"/>'\
+             "<c:tickLblPos val=\"#{@tick_lbl_pos}\"/>"
       # TODO - this is also being used for series colors
       # time to extract this into a class spPr - Shape Properties
       if @color
-        str << '<c:spPr><a:ln><a:solidFill>'
-        str << ('<a:srgbClr val="' << @color << '"/>')
-        str << '</a:solidFill></a:ln></c:spPr>'
+        str << '<c:spPr><a:ln><a:solidFill>'\
+               "<a:srgbClr val=\"#{@color}\"/>"\
+               '</a:solidFill></a:ln></c:spPr>'
       end
       # some potential value in implementing this in full. Very detailed!
-      str << ('<c:txPr><a:bodyPr rot="' << @label_rotation.to_s << '"/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:endParaRPr/></a:p></c:txPr>')
-      str << ('<c:crossAx val="' << @cross_axis.id.to_s << '"/>')
-      str << ('<c:crosses val="' << @crosses.to_s << '"/>')
+      str << "<c:txPr><a:bodyPr rot=\"#{@label_rotation}\"/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:endParaRPr/></a:p></c:txPr>"\
+             "<c:crossAx val=\"#{@cross_axis.id}\"/>"\
+             "<c:crosses val=\"#{@crosses}\"/>"
     end
 
   end

--- a/lib/axlsx/drawing/bar_3D_chart.rb
+++ b/lib/axlsx/drawing/bar_3D_chart.rb
@@ -41,7 +41,7 @@ module Axlsx
       @gap_width ||= 150
     end
     alias :gapWidth :gap_width
-    
+
     #grouping for a column, line, or area chart.
     # must be one of  [:percentStacked, :clustered, :standard, :stacked]
     # @return [Symbol]
@@ -126,15 +126,15 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       super(str) do
-        str << '<c:bar3DChart>'
-        str << ('<c:barDir val="' << bar_dir.to_s << '"/>')
-        str << ('<c:grouping val="' << grouping.to_s << '"/>')
-        str << ('<c:varyColors val="' << vary_colors.to_s << '"/>')
+        str << '<c:bar3DChart>'\
+               "<c:barDir val=\"#{bar_dir}\"/>"\
+               "<c:grouping val=\"#{grouping}\"/>"\
+               "<c:varyColors val=\"#{vary_colors}\"/>"
         @series.each { |ser| ser.to_xml_string(str) }
         @d_lbls.to_xml_string(str) if @d_lbls
-        str << ('<c:gapWidth val="' << @gap_width.to_s << '"/>') unless @gap_width.nil?
-        str << ('<c:gapDepth val="' << @gap_depth.to_s << '"/>') unless @gap_depth.nil?
-        str << ('<c:shape val="' << @shape.to_s << '"/>') unless @shape.nil?
+        str << "<c:gapWidth val=\"#{@gap_width}\"/>" unless @gap_width.nil?
+        str << "<c:gapDepth val=\"#{@gap_depth}\"/>" unless @gap_depth.nil?
+        str << "<c:shape val=\"#{@shape}\"/>" unless @shape.nil?
         axes.to_xml_string(str, :ids => true)
         str << '</c:bar3DChart>'
         axes.to_xml_string(str)

--- a/lib/axlsx/drawing/bar_3D_chart.rb
+++ b/lib/axlsx/drawing/bar_3D_chart.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # The Bar3DChart is a three dimentional barchart (who would have guessed?) that you can add to your worksheet.
@@ -124,7 +125,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       super(str) do
         str << '<c:bar3DChart>'\
                "<c:barDir val=\"#{bar_dir}\"/>"\

--- a/lib/axlsx/drawing/bar_chart.rb
+++ b/lib/axlsx/drawing/bar_chart.rb
@@ -118,15 +118,15 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       super(str) do
-        str << '<c:barChart>'
-        str << ('<c:barDir val="' << bar_dir.to_s << '"/>')
-        str << ('<c:grouping val="' << grouping.to_s << '"/>')
-        str << ('<c:varyColors val="' << vary_colors.to_s << '"/>')
+        str << '<c:barChart>'\
+               "<c:barDir val=\"#{bar_dir}\"/>"\
+               "<c:grouping val=\"#{grouping}\"/>"\
+               "<c:varyColors val=\"#{vary_colors}\"/>"
         @series.each { |ser| ser.to_xml_string(str) }
         @d_lbls.to_xml_string(str) if @d_lbls
-        str << ('<c:gapWidth val="' << @gap_width.to_s << '"/>') unless @gap_width.nil?
-        str << ('<c:gapDepth val="' << @gap_depth.to_s << '"/>') unless @gap_depth.nil?
-        str << ('<c:shape val="' << @shape.to_s << '"/>') unless @shape.nil?
+        str << "<c:gapWidth val=\"#{@gap_width}\"/>" unless @gap_width.nil?
+        str << "<c:gapDepth val=\"#{@gap_depth}\"/>" unless @gap_depth.nil?
+        str << "<c:shape val=\"#{@shape}\"/>" unless @shape.nil?
         axes.to_xml_string(str, :ids => true)
         str << '</c:barChart>'
         axes.to_xml_string(str)

--- a/lib/axlsx/drawing/bar_chart.rb
+++ b/lib/axlsx/drawing/bar_chart.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # The BarChart is a three dimentional barchart (who would have guessed?) that you can add to your worksheet.
@@ -116,7 +117,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       super(str) do
         str << '<c:barChart>'\
                "<c:barDir val=\"#{bar_dir}\"/>"\

--- a/lib/axlsx/drawing/bar_series.rb
+++ b/lib/axlsx/drawing/bar_series.rb
@@ -55,17 +55,17 @@ module Axlsx
       super(str) do
 
         colors.each_with_index do |c, index|
-          str << '<c:dPt>'
-          str << ('<c:idx val="' << index.to_s << '"/>')
-          str << '<c:spPr><a:solidFill>'
-          str << ('<a:srgbClr val="' << c << '"/>')
-          str << '</a:solidFill></c:spPr></c:dPt>'
+          str << '<c:dPt>'\
+                 "<c:idx val=\"#{index}\"/>"\
+                 '<c:spPr><a:solidFill>'\
+                 "<a:srgbClr val=\"#{c}\"/>"\
+                 '</a:solidFill></c:spPr></c:dPt>'
         end
 
         @labels.to_xml_string(str) unless @labels.nil?
         @data.to_xml_string(str) unless @data.nil?
-        # this is actually only required for shapes other than box 
-        str << ('<c:shape val="' << shape.to_s << '"></c:shape>')
+        # this is actually only required for shapes other than box
+        str << "<c:shape val=\"#{shape}\"></c:shape>"
       end
     end
 

--- a/lib/axlsx/drawing/bar_series.rb
+++ b/lib/axlsx/drawing/bar_series.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # A BarSeries defines the title, data and labels for bar charts
   # @note The recommended way to manage series is to use Chart#add_series
@@ -51,7 +52,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       super(str) do
 
         colors.each_with_index do |c, index|

--- a/lib/axlsx/drawing/bubble_chart.rb
+++ b/lib/axlsx/drawing/bubble_chart.rb
@@ -38,8 +38,8 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       super(str) do
-        str << '<c:bubbleChart>'
-        str << ('<c:varyColors val="' << vary_colors.to_s << '"/>')
+        str << '<c:bubbleChart>'\
+               "<c:varyColors val=\"#{vary_colors}\"/>"
         @series.each { |ser| ser.to_xml_string(str) }
         d_lbls.to_xml_string(str) if @d_lbls
         axes.to_xml_string(str, :ids => true)

--- a/lib/axlsx/drawing/bubble_chart.rb
+++ b/lib/axlsx/drawing/bubble_chart.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # The BubbleChart allows you to insert a bubble chart into your worksheet
@@ -36,7 +37,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       super(str) do
         str << '<c:bubbleChart>'\
                "<c:varyColors val=\"#{vary_colors}\"/>"

--- a/lib/axlsx/drawing/bubble_series.rb
+++ b/lib/axlsx/drawing/bubble_series.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # A BubbleSeries defines the x/y position and bubble size of data in the chart
@@ -42,7 +43,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       super(str) do
         # needs to override the super color here to push in ln/and something else!
         if color

--- a/lib/axlsx/drawing/bubble_series.rb
+++ b/lib/axlsx/drawing/bubble_series.rb
@@ -46,12 +46,12 @@ module Axlsx
       super(str) do
         # needs to override the super color here to push in ln/and something else!
         if color
-          str << '<c:spPr><a:solidFill>'
-          str << ('<a:srgbClr val="' << color << '"/>')
-          str << '</a:solidFill>'
-          str << '<a:ln><a:solidFill>'
-          str << ('<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>')
-          str << '</c:spPr>'
+          str << '<c:spPr><a:solidFill>'\
+                 "<a:srgbClr val=\"#{color}\"/>"\
+                 '</a:solidFill>'\
+                 '<a:ln><a:solidFill>'\
+                 "<a:srgbClr val=\"#{color}\"/></a:solidFill></a:ln>"\
+                 '</c:spPr>'
         end
         @xData.to_xml_string(str) unless @xData.nil?
         @yData.to_xml_string(str) unless @yData.nil?

--- a/lib/axlsx/drawing/cat_axis.rb
+++ b/lib/axlsx/drawing/cat_axis.rb
@@ -71,12 +71,12 @@ module Axlsx
     def to_xml_string(str = '')
       str << '<c:catAx>'
       super(str)
-      str << ('<c:auto val="' << @auto.to_s << '"/>')
-      str << ('<c:lblAlgn val="' << @lbl_algn.to_s << '"/>')
-      str << ('<c:lblOffset val="' << @lbl_offset.to_i.to_s << '"/>')
-      str << ('<c:tickLblSkip val="' << @tick_lbl_skip.to_s << '"/>')
-      str << ('<c:tickMarkSkip val="' << @tick_mark_skip.to_s << '"/>')
-      str << '</c:catAx>'
+      str << "<c:auto val=\"#{@auto}\"/>"\
+             "<c:lblAlgn val=\"#{@lbl_algn}\"/>"\
+             "<c:lblOffset val=\"#{@lbl_offset.to_i}\"/>"\
+             "<c:tickLblSkip val=\"#{@tick_lbl_skip}\"/>"\
+             "<c:tickMarkSkip val=\"#{@tick_mark_skip}\"/>"\
+             '</c:catAx>'
     end
 
   end

--- a/lib/axlsx/drawing/cat_axis.rb
+++ b/lib/axlsx/drawing/cat_axis.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   #A CatAxis object defines a chart category axis
   class CatAxis < Axis
@@ -68,7 +69,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<c:catAx>'
       super(str)
       str << "<c:auto val=\"#{@auto}\"/>"\

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # A Chart is the superclass for specific charts
@@ -183,7 +184,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<?xml version="1.0" encoding="UTF-8"?>'\
              "<c:chartSpace xmlns:c=\"#{XML_NS_C}\" xmlns:a=\"#{XML_NS_A}\" xmlns:r=\"#{XML_NS_R}\">"\
              "<c:date1904 val=\"#{Axlsx::Workbook.date1904}\"/>"

--- a/lib/axlsx/drawing/chart.rb
+++ b/lib/axlsx/drawing/chart.rb
@@ -184,48 +184,48 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << ('<c:chartSpace xmlns:c="' << XML_NS_C << '" xmlns:a="' << XML_NS_A << '" xmlns:r="' << XML_NS_R << '">')
-      str << ('<c:date1904 val="' << Axlsx::Workbook.date1904.to_s << '"/>')
-      str << ('<c:style val="' << style.to_s << '"/>')
-      str << '<c:chart>'
+      str << '<?xml version="1.0" encoding="UTF-8"?>'\
+             "<c:chartSpace xmlns:c=\"#{XML_NS_C}\" xmlns:a=\"#{XML_NS_A}\" xmlns:r=\"#{XML_NS_R}\">"\
+             "<c:date1904 val=\"#{Axlsx::Workbook.date1904}\"/>"
+      str << "<c:style val=\"#{style}\"/>"\
+             '<c:chart>'
       @title.to_xml_string str
-      str << ('<c:autoTitleDeleted val="' << (@title == nil).to_s << '"/>')
+      str << "<c:autoTitleDeleted val=\"#{@title == nil}\"/>"
       @view_3D.to_xml_string(str) if @view_3D
-      str << '<c:floor><c:thickness val="0"/></c:floor>'
-      str << '<c:sideWall><c:thickness val="0"/></c:sideWall>'
-      str << '<c:backWall><c:thickness val="0"/></c:backWall>'
-      str << '<c:plotArea>'
-      str << '<c:layout/>'
+      str << '<c:floor><c:thickness val="0"/></c:floor>'\
+             '<c:sideWall><c:thickness val="0"/></c:sideWall>'\
+             '<c:backWall><c:thickness val="0"/></c:backWall>'\
+             '<c:plotArea>'\
+             '<c:layout/>'
       yield if block_given?
       str << '</c:plotArea>'
       if @show_legend
-        str << '<c:legend>'
-        str << ('<c:legendPos val="' << @legend_position.to_s << '"/>')
-        str << '<c:layout/>'
-        str << '<c:overlay val="0"/>'
-        str << '</c:legend>'
+        str << '<c:legend>'\
+               "<c:legendPos val=\"#{@legend_position}\"/>"\
+               '<c:layout/>'\
+               '<c:overlay val="0"/>'\
+               '</c:legend>'
       end
-      str << '<c:plotVisOnly val="1"/>'
-      str << ('<c:dispBlanksAs val="' << display_blanks_as.to_s << '"/>')
-      str << '<c:showDLblsOverMax val="1"/>'
-      str << '</c:chart>'
+      str << '<c:plotVisOnly val="1"/>'\
+             "<c:dispBlanksAs val=\"#{display_blanks_as}\"/>"\
+             '<c:showDLblsOverMax val="1"/>'\
+             '</c:chart>'
       if bg_color
-        str << '<c:spPr>'
-        str << '<a:solidFill>'
-        str << '<a:srgbClr val="' << bg_color << '"/>'
-        str << '</a:solidFill>'
-        str << '<a:ln>'
-        str << '<a:noFill/>'
-        str << '</a:ln>'
-        str << '</c:spPr>'
+        str << '<c:spPr>'\
+               '<a:solidFill>'\
+               "<a:srgbClr val=\"#{bg_color}\"/>"\
+               '</a:solidFill>'\
+               '<a:ln>'\
+               '<a:noFill/>'\
+               '</a:ln>'\
+               '</c:spPr>'
       end
-      str << '<c:printSettings>'
-      str << '<c:headerFooter/>'
-      str << '<c:pageMargins b="1.0" l="0.75" r="0.75" t="1.0" header="0.5" footer="0.5"/>'
-      str << '<c:pageSetup/>'
-      str << '</c:printSettings>'
-      str << '</c:chartSpace>'
+      str << '<c:printSettings>'\
+             '<c:headerFooter/>'\
+             '<c:pageMargins b="1.0" l="0.75" r="0.75" t="1.0" header="0.5" footer="0.5"/>'\
+             '<c:pageSetup/>'\
+             '</c:printSettings>'\
+             '</c:chartSpace>'
     end
 
     # This is a short cut method to set the anchor start marker position

--- a/lib/axlsx/drawing/d_lbls.rb
+++ b/lib/axlsx/drawing/d_lbls.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # There are more elements in the dLbls spec that allow for
   # customizations and formatting. For now, I am just implementing the
@@ -68,7 +69,7 @@ module Axlsx
    
     # serializes the data labels
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       validate_attributes_for_chart_type
       str << '<c:dLbls>'
       %w(d_lbl_pos show_legend_key show_val show_cat_name show_ser_name show_percent show_bubble_size show_leader_lines).each do |key|

--- a/lib/axlsx/drawing/drawing.rb
+++ b/lib/axlsx/drawing/drawing.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   require 'axlsx/drawing/d_lbls.rb'
   require 'axlsx/drawing/title.rb'
@@ -156,7 +157,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'\
              "<xdr:wsDr xmlns:xdr=\"#{XML_NS_XDR}\" xmlns:a=\"#{XML_NS_A}\">"
       anchors.each { |anchor| anchor.to_xml_string(str) }

--- a/lib/axlsx/drawing/drawing.rb
+++ b/lib/axlsx/drawing/drawing.rb
@@ -157,8 +157,8 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-      str << ('<xdr:wsDr xmlns:xdr="' << XML_NS_XDR << '" xmlns:a="' << XML_NS_A << '">')
+      str << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'\
+             "<xdr:wsDr xmlns:xdr=\"#{XML_NS_XDR}\" xmlns:a=\"#{XML_NS_A}\">"
       anchors.each { |anchor| anchor.to_xml_string(str) }
       str << '</xdr:wsDr>'
     end

--- a/lib/axlsx/drawing/graphic_frame.rb
+++ b/lib/axlsx/drawing/graphic_frame.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # A graphic frame defines a container for a chart object
   # @note The recommended way to manage charts is Worksheet#add_chart
@@ -31,7 +32,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       # macro attribute should be optional!
       str << '<xdr:graphicFrame>'\
              '<xdr:nvGraphicFramePr>'\

--- a/lib/axlsx/drawing/graphic_frame.rb
+++ b/lib/axlsx/drawing/graphic_frame.rb
@@ -33,21 +33,21 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       # macro attribute should be optional!
-      str << '<xdr:graphicFrame>'
-      str << '<xdr:nvGraphicFramePr>'
-      str << ('<xdr:cNvPr id="' << @anchor.drawing.index.to_s << '" name="' << 'item_' << @anchor.drawing.index.to_s << '"/>')
-      str << '<xdr:cNvGraphicFramePr/>'
-      str << '</xdr:nvGraphicFramePr>'
-      str << '<xdr:xfrm>'
-      str << '<a:off x="0" y="0"/>'
-      str << '<a:ext cx="0" cy="0"/>'
-      str << '</xdr:xfrm>'
-      str << '<a:graphic>'
-      str << ('<a:graphicData uri="' << XML_NS_C << '">')
-      str << ('<c:chart xmlns:c="' << XML_NS_C << '" xmlns:r="' << XML_NS_R << '" r:id="' << rId << '"/>')
-      str << '</a:graphicData>'
-      str << '</a:graphic>'
-      str << '</xdr:graphicFrame>'
+      str << '<xdr:graphicFrame>'\
+             '<xdr:nvGraphicFramePr>'\
+             "<xdr:cNvPr id=\"#{@anchor.drawing.index}\" name=\"item_#{@anchor.drawing.index}\"/>"\
+             '<xdr:cNvGraphicFramePr/>'\
+             '</xdr:nvGraphicFramePr>'\
+             '<xdr:xfrm>'\
+             '<a:off x="0" y="0"/>'\
+             '<a:ext cx="0" cy="0"/>'\
+             '</xdr:xfrm>'\
+             '<a:graphic>'\
+             "<a:graphicData uri=\"#{XML_NS_C}\">"\
+             "<c:chart xmlns:c=\"#{XML_NS_C}\" xmlns:r=\"#{XML_NS_R}\" r:id=\"#{rId}\"/>"\
+             '</a:graphicData>'\
+             '</a:graphic>'\
+             '</xdr:graphicFrame>'
     end
 
   end

--- a/lib/axlsx/drawing/hyperlink.rb
+++ b/lib/axlsx/drawing/hyperlink.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # a hyperlink object adds an action to an image when clicked so that when the image is clicked the link is fecthed.
   # @note using the hyperlink option when calling add_image on a drawing object is the recommended way to manage hyperlinks
@@ -92,7 +93,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       serialized_tag 'a:hlinkClick', str, {:'r:id' => relationship.Id, :'xmlns:r' => XML_NS_R }
     end
 

--- a/lib/axlsx/drawing/line_3D_chart.rb
+++ b/lib/axlsx/drawing/line_3D_chart.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # The Line3DChart is a three dimentional line chart (who would have guessed?) that you can add to your worksheet.
@@ -59,7 +60,7 @@ module Axlsx
       # Serializes the object
       # @param [String] str
       # @return [String]
-      def to_xml_string(str = '')
+      def to_xml_string(str = String.new)
         super(str) do
           str << "<c:gapDepth val=\"#{@gap_depth}\"/>" unless @gap_depth.nil?
         end

--- a/lib/axlsx/drawing/line_3D_chart.rb
+++ b/lib/axlsx/drawing/line_3D_chart.rb
@@ -61,7 +61,7 @@ module Axlsx
       # @return [String]
       def to_xml_string(str = '')
         super(str) do
-          str << ('<c:gapDepth val="' << @gap_depth.to_s << '"/>') unless @gap_depth.nil?
+          str << "<c:gapDepth val=\"#{@gap_depth}\"/>" unless @gap_depth.nil?
         end
       end
   end

--- a/lib/axlsx/drawing/line_chart.rb
+++ b/lib/axlsx/drawing/line_chart.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # The LineChart is a two dimentional line chart (who would have guessed?) that you can add to your worksheet.
@@ -75,7 +76,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       super(str) do
         str << "<c:#{node_name}>"\
                "<c:grouping val=\"#{grouping}\"/>"\

--- a/lib/axlsx/drawing/line_chart.rb
+++ b/lib/axlsx/drawing/line_chart.rb
@@ -77,14 +77,14 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       super(str) do
-        str << ("<c:" << node_name << ">")
-        str << ('<c:grouping val="' << grouping.to_s << '"/>')
-        str << ('<c:varyColors val="' << vary_colors.to_s << '"/>')
+        str << "<c:#{node_name}>"\
+               "<c:grouping val=\"#{grouping}\"/>"\
+               "<c:varyColors val=\"#{vary_colors}\"/>"
         @series.each { |ser| ser.to_xml_string(str) }
         @d_lbls.to_xml_string(str) if @d_lbls
         yield if block_given?
         axes.to_xml_string(str, :ids => true)
-        str << ("</c:" << node_name << ">")
+        str << "</c:#{node_name}>"
         axes.to_xml_string(str)
       end
     end

--- a/lib/axlsx/drawing/line_series.rb
+++ b/lib/axlsx/drawing/line_series.rb
@@ -74,27 +74,27 @@ module Axlsx
     def to_xml_string(str = '')
       super(str) do
         if color
-          str << '<c:spPr><a:solidFill>'
-          str << ('<a:srgbClr val="' << color << '"/>')
-          str << '</a:solidFill>'
-          str << '<a:ln w="28800">'
-          str << '<a:solidFill>'
-          str << ('<a:srgbClr val="' << color << '"/>')
-          str << '</a:solidFill>'
-          str << '</a:ln>'
-          str << '<a:round/>'
-          str << '</c:spPr>'
+          str << '<c:spPr><a:solidFill>'\
+                 "<a:srgbClr val=\"#{color}\"/>"\
+                 '</a:solidFill>'\
+                 '<a:ln w="28800">'\
+                 '<a:solidFill>'\
+                 "<a:srgbClr val=\"#{color}\"/>"\
+                 '</a:solidFill>'\
+                 '</a:ln>'\
+                 '<a:round/>'\
+                 '</c:spPr>'
         end
 
         if !@show_marker
           str << '<c:marker><c:symbol val="none"/></c:marker>'
         elsif @marker_symbol != :default
-          str << '<c:marker><c:symbol val="' + @marker_symbol.to_s + '"/></c:marker>'
+          str << "<c:marker><c:symbol val=\"#{@marker_symbol}\"/></c:marker>"
         end
 
         @labels.to_xml_string(str) unless @labels.nil?
         @data.to_xml_string(str) unless @data.nil?
-        str << ('<c:smooth val="' << ((smooth) ? '1' : '0') << '"/>')
+        str << "<c:smooth val=\"#{smooth ? 1 : 0}\"/>"
       end
     end
 

--- a/lib/axlsx/drawing/line_series.rb
+++ b/lib/axlsx/drawing/line_series.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # A LineSeries defines the title, data and labels for line charts
   # @note The recommended way to manage series is to use Chart#add_series
@@ -71,7 +72,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       super(str) do
         if color
           str << '<c:spPr><a:solidFill>'\

--- a/lib/axlsx/drawing/marker.rb
+++ b/lib/axlsx/drawing/marker.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # The Marker class defines a point in the worksheet that drawing anchors attach to.
   # @note The recommended way to manage markers is Worksheet#add_chart Markers are created for a two cell anchor based on the :start and :end options.
@@ -56,7 +57,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       [:col, :colOff, :row, :rowOff].each do |k|
         str << "<xdr:#{k}>#{self.send(k)}</xdr:#{k}>"
       end

--- a/lib/axlsx/drawing/marker.rb
+++ b/lib/axlsx/drawing/marker.rb
@@ -58,7 +58,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       [:col, :colOff, :row, :rowOff].each do |k|
-        str << ('<xdr:' << k.to_s << '>' << self.send(k).to_s << '</xdr:' << k.to_s << '>')
+        str << "<xdr:#{k}>#{self.send(k)}</xdr:#{k}>"
       end
     end
     private

--- a/lib/axlsx/drawing/num_data.rb
+++ b/lib/axlsx/drawing/num_data.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 module Axlsx
 
   #This class specifies data for a particular data point. It is used for both numCache and numLit object
@@ -37,7 +38,7 @@ module Axlsx
     end
 
     # serialize the object
-    def to_xml_string(str = "")
+    def to_xml_string(str = String.new)
       str << "<c:#{@tag_name}>"
       str << "<c:formatCode>#{format_code}</c:formatCode>"
       str << "<c:ptCount val=\"#{@pt.size}\"/>"

--- a/lib/axlsx/drawing/num_data.rb
+++ b/lib/axlsx/drawing/num_data.rb
@@ -38,13 +38,13 @@ module Axlsx
 
     # serialize the object
     def to_xml_string(str = "")
-      str << ('<c:' << @tag_name.to_s << '>')
-      str << ('<c:formatCode>' << format_code.to_s << '</c:formatCode>')
-      str << ('<c:ptCount val="' << @pt.size.to_s << '"/>')
+      str << "<c:#{@tag_name}>"
+      str << "<c:formatCode>#{format_code}</c:formatCode>"
+      str << "<c:ptCount val=\"#{@pt.size}\"/>"
       @pt.each_with_index do |num_val, index|
         num_val.to_xml_string index, str
       end
-      str << ('</c:' << @tag_name.to_s << '>')
+      str << "</c:#{@tag_name}>"
     end
 
   end

--- a/lib/axlsx/drawing/num_data_source.rb
+++ b/lib/axlsx/drawing/num_data_source.rb
@@ -46,16 +46,16 @@ module Axlsx
     # serialize the object
     # @param [String] str
     def to_xml_string(str="")
-      str << ('<c:' << tag_name.to_s << '>')
+      str << "<c:#{tag_name}>"
       if @f
-        str << ('<c:' << @ref_tag_name.to_s << '>')
-        str << ('<c:f>' << @f.to_s << '</c:f>')
+        str << "<c:#{@ref_tag_name}>"\
+               "<c:f>#{@f}</c:f>"
       end
       @data.to_xml_string str
       if @f
-        str << ('</c:' << @ref_tag_name.to_s << '>')
+        str << "</c:#{@ref_tag_name}>"
       end
-      str << ('</c:' << tag_name.to_s << '>')
+      str << "</c:#{tag_name}>"
     end
   end
 end

--- a/lib/axlsx/drawing/num_data_source.rb
+++ b/lib/axlsx/drawing/num_data_source.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # A numeric data source for use by charts.
@@ -45,7 +46,7 @@ module Axlsx
 
     # serialize the object
     # @param [String] str
-    def to_xml_string(str="")
+    def to_xml_string(str = String.new)
       str << "<c:#{tag_name}>"
       if @f
         str << "<c:#{@ref_tag_name}>"\

--- a/lib/axlsx/drawing/num_val.rb
+++ b/lib/axlsx/drawing/num_val.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 module Axlsx
 
   #This class specifies data for a particular data point.
@@ -24,7 +25,7 @@ module Axlsx
     end
 
     # serialize the object
-    def to_xml_string(idx, str = "")
+    def to_xml_string(idx, str = String.new)
       Axlsx::validate_unsigned_int(idx)
       if !v.to_s.empty?
         str << "<c:pt idx=\"#{idx}\" formatCode=\"#{format_code}\"><c:v>#{v}</c:v></c:pt>"

--- a/lib/axlsx/drawing/num_val.rb
+++ b/lib/axlsx/drawing/num_val.rb
@@ -27,7 +27,7 @@ module Axlsx
     def to_xml_string(idx, str = "")
       Axlsx::validate_unsigned_int(idx)
       if !v.to_s.empty?
-        str << ('<c:pt idx="' << idx.to_s << '" formatCode="' << format_code << '"><c:v>' << v.to_s << '</c:v></c:pt>')
+        str << "<c:pt idx=\"#{idx}\" formatCode=\"#{format_code}\"><c:v>#{v}</c:v></c:pt>"
       end
     end
   end

--- a/lib/axlsx/drawing/one_cell_anchor.rb
+++ b/lib/axlsx/drawing/one_cell_anchor.rb
@@ -74,14 +74,14 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<xdr:oneCellAnchor>'
-      str << '<xdr:from>'
+      str << '<xdr:oneCellAnchor>'\
+             '<xdr:from>'
       from.to_xml_string(str)
-      str << '</xdr:from>'
-      str << ('<xdr:ext cx="' << ext[:cx].to_s << '" cy="' << ext[:cy].to_s << '"/>')
+      str << '</xdr:from>'\
+             "<xdr:ext cx=\"#{ext[:cx]}\" cy=\"#{ext[:cy]}\"/>"
       @object.to_xml_string(str)
-      str << '<xdr:clientData/>'
-      str << '</xdr:oneCellAnchor>'
+      str << '<xdr:clientData/>'\
+             '</xdr:oneCellAnchor>'
     end
 
     private

--- a/lib/axlsx/drawing/one_cell_anchor.rb
+++ b/lib/axlsx/drawing/one_cell_anchor.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # This class details a single cell anchor for drawings.
   # @note The recommended way to manage drawings, images and charts is Worksheet#add_chart or Worksheet#add_image.
@@ -73,7 +74,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<xdr:oneCellAnchor>'\
              '<xdr:from>'
       from.to_xml_string(str)

--- a/lib/axlsx/drawing/pic.rb
+++ b/lib/axlsx/drawing/pic.rb
@@ -166,22 +166,22 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<xdr:pic>'
-      str << '<xdr:nvPicPr>'
-      str << ('<xdr:cNvPr id="2" name="' << name.to_s << '" descr="' << descr.to_s << '">')
+      str << '<xdr:pic>'\
+             '<xdr:nvPicPr>'\
+             "<xdr:cNvPr id=\"2\" name=\"#{name}\" descr=\"#{descr}\">"
       hyperlink.to_xml_string(str) if hyperlink.is_a?(Hyperlink)
       str << '</xdr:cNvPr><xdr:cNvPicPr>'
       picture_locking.to_xml_string(str)
-      str << '</xdr:cNvPicPr></xdr:nvPicPr>'
-      str << '<xdr:blipFill>'
-      str << ('<a:blip xmlns:r ="' << XML_NS_R << '" r:embed="' << relationship.Id << '">')
+      str << '</xdr:cNvPicPr></xdr:nvPicPr>'\
+             '<xdr:blipFill>'\
+             "<a:blip xmlns:r =\"#{XML_NS_R}\" r:embed=\"#{relationship.Id}\">"
       if opacity
         str << "<a:alphaModFix amt=\"#{opacity}\"/>"
       end
-      str << '</a:blip>'
-      str << '<a:stretch><a:fillRect/></a:stretch></xdr:blipFill><xdr:spPr>'
-      str << '<a:xfrm><a:off x="0" y="0"/><a:ext cx="2336800" cy="2161540"/></a:xfrm>'
-      str << '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></xdr:spPr></xdr:pic>'
+      str << '</a:blip>'\
+             '<a:stretch><a:fillRect/></a:stretch></xdr:blipFill><xdr:spPr>'\
+             '<a:xfrm><a:off x="0" y="0"/><a:ext cx="2336800" cy="2161540"/></a:xfrm>'\
+             '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></xdr:spPr></xdr:pic>'
     end
 
     private

--- a/lib/axlsx/drawing/pic.rb
+++ b/lib/axlsx/drawing/pic.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # a Pic object represents an image in your worksheet
   # Worksheet#add_image is the recommended way to manage images in your sheets
@@ -165,7 +166,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<xdr:pic>'\
              '<xdr:nvPicPr>'\
              "<xdr:cNvPr id=\"2\" name=\"#{name}\" descr=\"#{descr}\">"

--- a/lib/axlsx/drawing/picture_locking.rb
+++ b/lib/axlsx/drawing/picture_locking.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # The picture locking class defines the locking properties for pictures in your workbook.
   class PictureLocking
@@ -34,7 +35,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       serialized_tag('a:picLocks', str)
     end
 

--- a/lib/axlsx/drawing/pie_3D_chart.rb
+++ b/lib/axlsx/drawing/pie_3D_chart.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
 
@@ -33,7 +34,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       super(str) do
         str << '<c:pie3DChart>'\
                "<c:varyColors val=\"#{vary_colors}\"/>"

--- a/lib/axlsx/drawing/pie_3D_chart.rb
+++ b/lib/axlsx/drawing/pie_3D_chart.rb
@@ -35,8 +35,8 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       super(str) do
-        str << '<c:pie3DChart>'
-        str << ('<c:varyColors val="' << vary_colors.to_s << '"/>')
+        str << '<c:pie3DChart>'\
+               "<c:varyColors val=\"#{vary_colors}\"/>"
         @series.each { |ser| ser.to_xml_string(str) }
         d_lbls.to_xml_string(str) if @d_lbls
         str << '</c:pie3DChart>'

--- a/lib/axlsx/drawing/pie_series.rb
+++ b/lib/axlsx/drawing/pie_series.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # A PieSeries defines the data and labels and explosion for pie charts series.
@@ -45,7 +46,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       super(str) do
         str << "<c:explosion val=\"#{@explosion}\"/>" unless @explosion.nil?
         colors.each_with_index do |c, index|

--- a/lib/axlsx/drawing/pie_series.rb
+++ b/lib/axlsx/drawing/pie_series.rb
@@ -47,13 +47,13 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       super(str) do
-        str << '<c:explosion val="' + @explosion + '"/>' unless @explosion.nil?
+        str << "<c:explosion val=\"#{@explosion}\"/>" unless @explosion.nil?
         colors.each_with_index do |c, index|
-          str << '<c:dPt>'
-          str << ('<c:idx val="' << index.to_s << '"/>')
-          str << '<c:spPr><a:solidFill>'
-          str << ('<a:srgbClr val="' << c << '"/>')
-          str << '</a:solidFill></c:spPr></c:dPt>'
+          str << '<c:dPt>'\
+                 "<c:idx val=\"#{index}\"/>"\
+                 '<c:spPr><a:solidFill>'\
+                 "<a:srgbClr val=\"#{c}\"/>"\
+                 '</a:solidFill></c:spPr></c:dPt>'
         end
         @labels.to_xml_string str unless @labels.nil?
         @data.to_xml_string str unless @data.nil?

--- a/lib/axlsx/drawing/scaling.rb
+++ b/lib/axlsx/drawing/scaling.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # The Scaling class defines axis scaling
   class Scaling
@@ -47,7 +48,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<c:scaling>'
       str << "<c:logBase val=\"#{@logBase}\"/>" unless @logBase.nil?
       str << "<c:orientation val=\"#{@orientation}\"/>" unless @orientation.nil?

--- a/lib/axlsx/drawing/scaling.rb
+++ b/lib/axlsx/drawing/scaling.rb
@@ -49,10 +49,10 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       str << '<c:scaling>'
-      str << ('<c:logBase val="' << @logBase.to_s << '"/>') unless @logBase.nil?
-      str << ('<c:orientation val="' << @orientation.to_s << '"/>') unless @orientation.nil?
-      str << ('<c:min val="' << @min.to_s << '"/>') unless @min.nil?
-      str << ('<c:max val="' << @max.to_s << '"/>') unless @max.nil?
+      str << "<c:logBase val=\"#{@logBase}\"/>" unless @logBase.nil?
+      str << "<c:orientation val=\"#{@orientation}\"/>" unless @orientation.nil?
+      str << "<c:min val=\"#{@min}\"/>" unless @min.nil?
+      str << "<c:max val=\"#{@max}\"/>" unless @max.nil?
       str << '</c:scaling>'
     end
 

--- a/lib/axlsx/drawing/scatter_chart.rb
+++ b/lib/axlsx/drawing/scatter_chart.rb
@@ -52,9 +52,9 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       super(str) do
-        str << '<c:scatterChart>'
-        str << ('<c:scatterStyle val="' << scatter_style.to_s << '"/>')
-        str << ('<c:varyColors val="' << vary_colors.to_s << '"/>')
+        str << '<c:scatterChart>'\
+               "<c:scatterStyle val=\"#{scatter_style}\"/>"\
+               "<c:varyColors val=\"#{vary_colors}\"/>"
         @series.each { |ser| ser.to_xml_string(str) }
         d_lbls.to_xml_string(str) if @d_lbls
         axes.to_xml_string(str, :ids => true)

--- a/lib/axlsx/drawing/scatter_chart.rb
+++ b/lib/axlsx/drawing/scatter_chart.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # The ScatterChart allows you to insert a scatter chart into your worksheet
@@ -50,7 +51,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       super(str) do
         str << '<c:scatterChart>'\
                "<c:scatterStyle val=\"#{scatter_style}\"/>"\

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # A ScatterSeries defines the x and y position of data in the chart
@@ -64,7 +65,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       super(str) do
         # needs to override the super color here to push in ln/and something else!
         if color

--- a/lib/axlsx/drawing/scatter_series.rb
+++ b/lib/axlsx/drawing/scatter_series.rb
@@ -68,29 +68,29 @@ module Axlsx
       super(str) do
         # needs to override the super color here to push in ln/and something else!
         if color
-          str << '<c:spPr><a:solidFill>'
-          str << ('<a:srgbClr val="' << color << '"/>')
-          str << '</a:solidFill>'
-          str << '<a:ln><a:solidFill>'
-          str << ('<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>')
-          str << '</c:spPr>'
-          str << '<c:marker>'
-          str << '<c:spPr><a:solidFill>'
-          str << ('<a:srgbClr val="' << color << '"/>')
-          str << '</a:solidFill>'
-          str << '<a:ln><a:solidFill>'
-          str << ('<a:srgbClr val="' << color << '"/></a:solidFill></a:ln>')
-          str << '</c:spPr>'
-          str << '</c:marker>'
+          str << '<c:spPr><a:solidFill>'\
+                 "<a:srgbClr val=\"#{color}\"/>"\
+                 '</a:solidFill>'\
+                 '<a:ln><a:solidFill>'\
+                 "<a:srgbClr val=\"#{color}\"/></a:solidFill></a:ln>"\
+                 '</c:spPr>'\
+                 '<c:marker>'\
+                 '<c:spPr><a:solidFill>'\
+                 "<a:srgbClr val=\"#{color}\"/>"\
+                 '</a:solidFill>'\
+                 '<a:ln><a:solidFill>'\
+                 "<a:srgbClr val=\"#{color}\"/></a:solidFill></a:ln>"\
+                 '</c:spPr>'\
+                 '</c:marker>'
         end
         if ln_width
-          str << '<c:spPr>'
-          str << '<a:ln w="' << ln_width.to_s << '"/>'
-          str << '</c:spPr>'
+          str << '<c:spPr>'\
+                 "<a:ln w=\"#{ln_width}\"/>"
+                 '</c:spPr>'
         end
         @xData.to_xml_string(str) unless @xData.nil?
         @yData.to_xml_string(str) unless @yData.nil?
-        str << ('<c:smooth val="' << ((smooth) ? '1' : '0') << '"/>')
+        str << "<c:smooth val=\"#{smooth ? 1 : 0}\"/>"
       end
       str
     end

--- a/lib/axlsx/drawing/ser_axis.rb
+++ b/lib/axlsx/drawing/ser_axis.rb
@@ -35,8 +35,8 @@ module Axlsx
     def to_xml_string(str = '')
       str << '<c:serAx>'
       super(str)
-      str << ('<c:tickLblSkip val="' << @tick_lbl_skip.to_s << '"/>') unless @tick_lbl_skip.nil?
-      str << ('<c:tickMarkSkip val="' << @tick_mark_skip.to_s << '"/>') unless @tick_mark_skip.nil?
+      str << "<c:tickLblSkip val=\"#{@tick_lbl_skip}\"/>" unless @tick_lbl_skip.nil?
+      str << "<c:tickMarkSkip val=\"#{@tick_mark_skip}\"/>" unless @tick_mark_skip.nil?
       str << '</c:serAx>'
     end
   end

--- a/lib/axlsx/drawing/ser_axis.rb
+++ b/lib/axlsx/drawing/ser_axis.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   #A SerAxis object defines a series axis
   class SerAxis < Axis
@@ -32,7 +33,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<c:serAx>'
       super(str)
       str << "<c:tickLblSkip val=\"#{@tick_lbl_skip}\"/>" unless @tick_lbl_skip.nil?

--- a/lib/axlsx/drawing/series.rb
+++ b/lib/axlsx/drawing/series.rb
@@ -58,9 +58,9 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<c:ser>'
-      str << ('<c:idx val="' << index.to_s << '"/>')
-      str << ('<c:order val="' << (order || index).to_s << '"/>')
+      str << '<c:ser>'\
+             "<c:idx val=\"#{index}\"/>"\
+             "<c:order val=\"#{order || index}\"/>"
       title.to_xml_string(str) unless title.nil?
       yield if block_given?
       str << '</c:ser>'

--- a/lib/axlsx/drawing/series.rb
+++ b/lib/axlsx/drawing/series.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # A Series defines the common series attributes and is the super class for all concrete series types.
   # @note The recommended way to manage series is to use Chart#add_series
@@ -57,7 +58,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<c:ser>'\
              "<c:idx val=\"#{index}\"/>"\
              "<c:order val=\"#{order || index}\"/>"

--- a/lib/axlsx/drawing/series_title.rb
+++ b/lib/axlsx/drawing/series_title.rb
@@ -7,17 +7,17 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<c:tx>'
-      str << '<c:strRef>'
-      str << ('<c:f>' << Axlsx::cell_range([@cell]) << '</c:f>')
-      str << '<c:strCache>'
-      str << '<c:ptCount val="1"/>'
-      str << '<c:pt idx="0">'
-      str << ('<c:v>' << @text << '</c:v>')
-      str << '</c:pt>'
-      str << '</c:strCache>'
-      str << '</c:strRef>'
-      str << '</c:tx>'
+      str << '<c:tx>'\
+             '<c:strRef>'\
+             "<c:f>#{Axlsx::cell_range([@cell])}</c:f>"\
+             '<c:strCache>'\
+             '<c:ptCount val="1"/>'\
+             '<c:pt idx="0">'\
+             "<c:v>#{@text}</c:v>"\
+             '</c:pt>'\
+             '</c:strCache>'\
+             '</c:strRef>'\
+             '</c:tx>'
     end
   end
 end

--- a/lib/axlsx/drawing/series_title.rb
+++ b/lib/axlsx/drawing/series_title.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # A series title is a Title with a slightly different serialization than chart titles.
   class SeriesTitle < Title
@@ -6,7 +7,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<c:tx>'\
              '<c:strRef>'\
              "<c:f>#{Axlsx::cell_range([@cell])}</c:f>"\

--- a/lib/axlsx/drawing/str_data.rb
+++ b/lib/axlsx/drawing/str_data.rb
@@ -29,12 +29,12 @@ module Axlsx
 
     # serialize the object
     def to_xml_string(str = "")
-      str << ('<c:' << @tag_name.to_s << '>')
-      str << ('<c:ptCount val="' << @pt.size.to_s << '"/>')
+      str << "<c:#{@tag_name}>"
+      str << "<c:ptCount val=\"#{@pt.size}\"/>"
       @pt.each_with_index do |value, index|
         value.to_xml_string index, str
       end
-      str << ('</c:' << @tag_name.to_s << '>')
+      str << "</c:#{@tag_name}>"
     end
 
   end

--- a/lib/axlsx/drawing/str_data.rb
+++ b/lib/axlsx/drawing/str_data.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 module Axlsx
 
   #This specifies the last string data used for a chart. (e.g. strLit and strCache)
@@ -28,7 +29,7 @@ module Axlsx
     end
 
     # serialize the object
-    def to_xml_string(str = "")
+    def to_xml_string(str = String.new)
       str << "<c:#{@tag_name}>"
       str << "<c:ptCount val=\"#{@pt.size}\"/>"
       @pt.each_with_index do |value, index|

--- a/lib/axlsx/drawing/str_val.rb
+++ b/lib/axlsx/drawing/str_val.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 module Axlsx
 
   #This class specifies data for a particular data point.
@@ -24,7 +25,7 @@ module Axlsx
     end
 
     # serialize the object
-    def to_xml_string(idx, str = "")
+    def to_xml_string(idx, str = String.new)
       Axlsx::validate_unsigned_int(idx)
       if !v.to_s.empty?
         str << "<c:pt idx=\"#{idx}\"><c:v>#{::CGI.escapeHTML(v.to_s)}</c:v></c:pt>"

--- a/lib/axlsx/drawing/str_val.rb
+++ b/lib/axlsx/drawing/str_val.rb
@@ -27,7 +27,7 @@ module Axlsx
     def to_xml_string(idx, str = "")
       Axlsx::validate_unsigned_int(idx)
       if !v.to_s.empty?
-        str << ('<c:pt idx="' << idx.to_s << '"><c:v>' << ::CGI.escapeHTML(v.to_s) << '</c:v></c:pt>')
+        str << "<c:pt idx=\"#{idx}\"><c:v>#{::CGI.escapeHTML(v.to_s)}</c:v></c:pt>"
       end
     end
   end

--- a/lib/axlsx/drawing/title.rb
+++ b/lib/axlsx/drawing/title.rb
@@ -64,32 +64,32 @@ module Axlsx
       unless @text.empty?
         str << '<c:tx>'
         if @cell.is_a?(Cell)
-          str << '<c:strRef>'
-          str << ('<c:f>' << Axlsx::cell_range([@cell]) << '</c:f>')
-          str << '<c:strCache>'
-          str << '<c:ptCount val="1"/>'
-          str << '<c:pt idx="0">'
-          str << ('<c:v>' << @text << '</c:v>')
-          str << '</c:pt>'
-          str << '</c:strCache>'
-          str << '</c:strRef>'
+          str << '<c:strRef>'\
+                 "<c:f>#{Axlsx::cell_range([@cell])}</c:f>"\
+                 '<c:strCache>'\
+                 '<c:ptCount val="1"/>'\
+                 '<c:pt idx="0">'\
+                 "<c:v>#{@text}</c:v>"\
+                 '</c:pt>'\
+                 '</c:strCache>'\
+                 '</c:strRef>'
         else
-          str << '<c:rich>'
-            str << '<a:bodyPr/>'
-            str << '<a:lstStyle/>'
-            str << '<a:p>'
-              str << '<a:r>'
-                str << ('<a:rPr sz="' << @text_size.to_s << '"/>')
-                str << ('<a:t>' << @text.to_s << '</a:t>')
-              str << '</a:r>'
-            str << '</a:p>'
-          str << '</c:rich>'
+          str << '<c:rich>'\
+                   '<a:bodyPr/>'\
+                   '<a:lstStyle/>'\
+                   '<a:p>'\
+                     '<a:r>'\
+                       "<a:rPr sz=\"#{@text_size}\"/>"\
+                       "<a:t>#{@text}</a:t>"\
+                     '</a:r>'\
+                   '</a:p>'\
+                 '</c:rich>'
         end
         str << '</c:tx>'
       end
-      str << '<c:layout/>'
-      str << '<c:overlay val="0"/>'
-      str << '</c:title>'
+      str << '<c:layout/>'\
+             '<c:overlay val="0"/>'\
+             '</c:title>'
     end
 
   end

--- a/lib/axlsx/drawing/title.rb
+++ b/lib/axlsx/drawing/title.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # A Title stores information about the title of a chart
   class Title
@@ -59,7 +60,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<c:title>'
       unless @text.empty?
         str << '<c:tx>'

--- a/lib/axlsx/drawing/two_cell_anchor.rb
+++ b/lib/axlsx/drawing/two_cell_anchor.rb
@@ -82,16 +82,16 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<xdr:twoCellAnchor>'
-      str << '<xdr:from>'
+      str << '<xdr:twoCellAnchor>'\
+             '<xdr:from>'
       from.to_xml_string str
-      str << '</xdr:from>'
-      str << '<xdr:to>'
+      str << '</xdr:from>'\
+             '<xdr:to>'
       to.to_xml_string str
       str << '</xdr:to>'
       object.to_xml_string(str)
-      str << '<xdr:clientData/>'
-      str << '</xdr:twoCellAnchor>'
+      str << '<xdr:clientData/>'\
+             '</xdr:twoCellAnchor>'
     end
   end
 end

--- a/lib/axlsx/drawing/two_cell_anchor.rb
+++ b/lib/axlsx/drawing/two_cell_anchor.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # This class details the anchor points for drawings.
   # @note The recommended way to manage drawings and charts is Worksheet#add_chart. Anchors are specified by the :start_at and :end_at options to that method.
@@ -81,7 +82,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<xdr:twoCellAnchor>'\
              '<xdr:from>'
       from.to_xml_string str

--- a/lib/axlsx/drawing/val_axis.rb
+++ b/lib/axlsx/drawing/val_axis.rb
@@ -29,8 +29,8 @@ module Axlsx
     def to_xml_string(str = '')
       str << '<c:valAx>'
       super(str)
-      str << ('<c:crossBetween val="' << @cross_between.to_s << '"/>')
-      str << '</c:valAx>'
+      str << "<c:crossBetween val=\"#{@cross_between}\"/>"\
+             '</c:valAx>'
     end
 
   end

--- a/lib/axlsx/drawing/val_axis.rb
+++ b/lib/axlsx/drawing/val_axis.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # the ValAxis class defines a chart value axis.
   class ValAxis < Axis
@@ -26,7 +27,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<c:valAx>'
       super(str)
       str << "<c:crossBetween val=\"#{@cross_between}\"/>"\

--- a/lib/axlsx/drawing/view_3D.rb
+++ b/lib/axlsx/drawing/view_3D.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # 3D attributes for a chart.
   class View3D
@@ -71,7 +72,7 @@ module Axlsx
     alias :hPercent= :h_percent=
 
       # @see rot_y
-      def rot_y=(v) 
+      def rot_y=(v)
         RangeValidator.validate "View3D.rot_y", 0, 360, v
         @rot_y = v
       end
@@ -96,7 +97,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<c:view3D>'
       %w(rot_x h_percent rot_y depth_percent r_ang_ax perspective).each do |key|
         str << element_for_attribute(key, 'c')

--- a/lib/axlsx/drawing/view_3D.rb
+++ b/lib/axlsx/drawing/view_3D.rb
@@ -109,7 +109,7 @@ module Axlsx
     def element_for_attribute(name, namespace='')
       val = instance_values[name]
       return "" if val == nil
-      "<%s:%s val='%s'/>" % [namespace, Axlsx::camel(name, false), val]
+      "<#{namespace}:#{Axlsx::camel(name, false)} val='#{val}'/>"
     end
   end
 end

--- a/lib/axlsx/drawing/vml_drawing.rb
+++ b/lib/axlsx/drawing/vml_drawing.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # a vml drawing used for comments in excel.
@@ -19,7 +20,7 @@ module Axlsx
     # serialize the vml_drawing to xml.
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << <<BAD_PROGRAMMER
 <xml xmlns:v="urn:schemas-microsoft-com:vml"
  xmlns:o="urn:schemas-microsoft-com:office:office"

--- a/lib/axlsx/drawing/vml_shape.rb
+++ b/lib/axlsx/drawing/vml_shape.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # A VmlShape is used to position and render a comment.
@@ -37,7 +38,7 @@ module Axlsx
     # serialize the shape to a string
     # @param [String] str
     # @return [String]
-    def to_xml_string(str ='')
+    def to_xml_string(str = String.new)
 str << <<SHAME_ON_YOU
 
 <v:shape id="#{@id}" type="#_x0000_t202" fillcolor="#ffffa1 [80]" o:insetmode="auto"

--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 module Axlsx
   # Package is responsible for managing all the bits and peices that Open Office XML requires to make a valid
   # xlsx document including valdation and serialization.

--- a/lib/axlsx/rels/relationship.rb
+++ b/lib/axlsx/rels/relationship.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # A relationship defines a reference between package parts.
   # @note Packages automatically manage relationships.
@@ -99,7 +100,7 @@ module Axlsx
     # serialize relationship
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       h = self.instance_values.reject{|k, _| k == "source_obj"}
       str << '<Relationship'
       h.each { |key, value| str << " #{key}=\"#{Axlsx::coder.encode(value.to_s)}\"" }

--- a/lib/axlsx/rels/relationship.rb
+++ b/lib/axlsx/rels/relationship.rb
@@ -3,28 +3,28 @@ module Axlsx
   # A relationship defines a reference between package parts.
   # @note Packages automatically manage relationships.
   class Relationship
-    
+
     class << self
       # Keeps track of all instances of this class.
       # @return [Array]
       def instances
         @instances ||= []
       end
-      
+
       # Clear cached instances.
-      # 
+      #
       # This should be called before serializing a package (see {Package#serialize} and
-      # {Package#to_stream}) to make sure that serialization is idempotent (i.e. 
+      # {Package#to_stream}) to make sure that serialization is idempotent (i.e.
       # Relationship instances are generated with the same IDs everytime the package
       # is serialized).
-      # 
-      # Also, calling this avoids memory leaks (cached instances lingering around 
-      # forever). 
+      #
+      # Also, calling this avoids memory leaks (cached instances lingering around
+      # forever).
       def clear_cached_instances
         @instances = []
       end
-      
-      # Generate and return a unique id (eg. `rId123`) Used for setting {#Id}. 
+
+      # Generate and return a unique id (eg. `rId123`) Used for setting {#Id}.
       #
       # The generated id depends on the number of cached instances, so using
       # {clear_cached_instances} will automatically reset the generated ids, too.
@@ -34,12 +34,12 @@ module Axlsx
       end
     end
 
-    # The id of the relationship (eg. "rId123"). Most instances get their own unique id. 
+    # The id of the relationship (eg. "rId123"). Most instances get their own unique id.
     # However, some instances need to share the same id – see {#should_use_same_id_as?}
     # for details.
     # @return [String]
     attr_reader :Id
-    
+
     # The location of the relationship target
     # @return [String]
     attr_reader :Target
@@ -69,8 +69,8 @@ module Axlsx
     # The source object the relations belongs to (e.g. a hyperlink, drawing, ...). Needed when
     # looking up the relationship for a specific object (see {Relationships#for}).
     attr_reader :source_obj
-    
-    # Initializes a new relationship. 
+
+    # Initializes a new relationship.
     # @param [Object] source_obj see {#source_obj}
     # @param [String] type The type of the relationship
     # @param [String] target The target for the relationship
@@ -101,16 +101,16 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = '')
       h = self.instance_values.reject{|k, _| k == "source_obj"}
-      str << '<Relationship '
-      str << (h.map { |key, value| '' << key.to_s << '="' << Axlsx::coder.encode(value.to_s) << '"'}.join(' '))
+      str << '<Relationship'
+      h.each { |key, value| str << " #{key}=\"#{Axlsx::coder.encode(value.to_s)}\"" }
       str << '/>'
     end
-    
+
     # Whether this relationship should use the same id as `other`.
     #
     # Instances designating the same relationship need to use the same id. We can not simply
-    # compare the {#Target} attribute, though: `foo/bar.xml`, `../foo/bar.xml`, 
-    # `../../foo/bar.xml` etc. are all different but probably mean the same file (this 
+    # compare the {#Target} attribute, though: `foo/bar.xml`, `../foo/bar.xml`,
+    # `../../foo/bar.xml` etc. are all different but probably mean the same file (this
     # is especially an issue for relationships in the context of pivot tables). So lets
     # just ignore this attribute for now (except when {#TargetMode} is set to `:External` –
     # then {#Target} will be an absolute URL and thus can safely be compared).
@@ -124,6 +124,6 @@ module Axlsx
       end
       result
     end
-    
+
   end
 end

--- a/lib/axlsx/rels/relationships.rb
+++ b/lib/axlsx/rels/relationships.rb
@@ -22,8 +22,8 @@ require 'axlsx/rels/relationship.rb'
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << ('<Relationships xmlns="' << RELS_R << '">')
+      str << '<?xml version="1.0" encoding="UTF-8"?>'\
+             "<Relationships xmlns=\"#{RELS_R}\">"
       each{ |rel| rel.to_xml_string(str) }
       str << '</Relationships>'
     end

--- a/lib/axlsx/rels/relationships.rb
+++ b/lib/axlsx/rels/relationships.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 require 'axlsx/rels/relationship.rb'
 
@@ -21,7 +22,7 @@ require 'axlsx/rels/relationship.rb'
     # serialize relationships
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<?xml version="1.0" encoding="UTF-8"?>'\
              "<Relationships xmlns=\"#{RELS_R}\">"
       each{ |rel| rel.to_xml_string(str) }

--- a/lib/axlsx/stylesheet/border.rb
+++ b/lib/axlsx/stylesheet/border.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # This class details a border used in Office Open XML spreadsheet styles.
   class Border
@@ -54,7 +55,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<border '
       serialized_attributes str
       str << '>'

--- a/lib/axlsx/stylesheet/border_pr.rb
+++ b/lib/axlsx/stylesheet/border_pr.rb
@@ -62,9 +62,9 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << ('<' << @name.to_s << ' style="' << @style.to_s << '">')
+      str << "<#{@name} style=\"#{@style}\">"
       @color.to_xml_string(str) if @color.is_a?(Color)
-      str << ('</' << @name.to_s << '>')
+      str << "</#{@name}>"
     end
 
   end

--- a/lib/axlsx/stylesheet/border_pr.rb
+++ b/lib/axlsx/stylesheet/border_pr.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # A border part.
   class BorderPr
@@ -61,7 +62,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << "<#{@name} style=\"#{@style}\">"
       @color.to_xml_string(str) if @color.is_a?(Color)
       str << "</#{@name}>"

--- a/lib/axlsx/stylesheet/cell_alignment.rb
+++ b/lib/axlsx/stylesheet/cell_alignment.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   
  
@@ -124,7 +125,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       serialized_tag('alignment', str)
     end
 

--- a/lib/axlsx/stylesheet/cell_protection.rb
+++ b/lib/axlsx/stylesheet/cell_protection.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # CellProtection stores information about locking or hiding cells in spreadsheet.
   # @note Using Styles#add_style is the recommended way to manage cell protection.
@@ -33,7 +34,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       serialized_tag('protection', str)
     end
 

--- a/lib/axlsx/stylesheet/cell_style.rb
+++ b/lib/axlsx/stylesheet/cell_style.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # CellStyle defines named styles that reference defined formatting records and can be used in your worksheet.
   # @note Using Styles#add_style is the recommended way to manage cell styling.
@@ -63,7 +64,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       serialized_tag('cellStyle', str)
     end
 

--- a/lib/axlsx/stylesheet/color.rb
+++ b/lib/axlsx/stylesheet/color.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # The color class represents a color used for borders, fills an fonts
   class Color
@@ -69,7 +70,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '', tag_name = 'color')
+    def to_xml_string(str = String.new, tag_name = 'color')
       serialized_tag(tag_name, str)
     end
   end

--- a/lib/axlsx/stylesheet/color.rb
+++ b/lib/axlsx/stylesheet/color.rb
@@ -70,7 +70,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '', tag_name = 'color')
-      serialized_tag('' + tag_name + '', str)
+      serialized_tag(tag_name, str)
     end
   end
 end

--- a/lib/axlsx/stylesheet/dxf.rb
+++ b/lib/axlsx/stylesheet/dxf.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # The Dxf class defines an incremental formatting record for use in Styles. The recommended way to manage styles for your workbook is with Styles#add_style
   # @see Styles#add_style
@@ -64,7 +65,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<dxf>'
       # Dxf elements have no attributes. All of the instance variables
       # are child elements.

--- a/lib/axlsx/stylesheet/fill.rb
+++ b/lib/axlsx/stylesheet/fill.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # The Fill is a formatting object that manages the background color, and pattern for cells.
   # @note The recommended way to manage styles in your workbook is to use Styles#add_style.
@@ -21,7 +22,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<fill>'
       @fill_type.to_xml_string(str)
       str << '</fill>'

--- a/lib/axlsx/stylesheet/font.rb
+++ b/lib/axlsx/stylesheet/font.rb
@@ -140,7 +140,7 @@ module Axlsx
     def to_xml_string(str = '')
       str << '<font>'
       instance_values.each do |k, v|
-        v.is_a?(Color) ? v.to_xml_string(str) : (str << ('<' << k.to_s << ' val="' << Axlsx.booleanize(v).to_s << '"/>'))
+        v.is_a?(Color) ? v.to_xml_string(str) : (str << "<#{k} val=\"#{Axlsx.booleanize(v)}\"/>")
       end
       str << '</font>'
     end

--- a/lib/axlsx/stylesheet/font.rb
+++ b/lib/axlsx/stylesheet/font.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # The Font class details a font instance for use in styling cells.
   # @note The recommended way to manage fonts, and other styles is Styles#add_style
@@ -137,7 +138,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<font>'
       instance_values.each do |k, v|
         v.is_a?(Color) ? v.to_xml_string(str) : (str << "<#{k} val=\"#{Axlsx.booleanize(v)}\"/>")

--- a/lib/axlsx/stylesheet/gradient_fill.rb
+++ b/lib/axlsx/stylesheet/gradient_fill.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # A GradientFill defines the color and positioning for gradiant cell fill.
   # @see Open Office XML Part 1 §18.8.24
@@ -92,7 +93,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<gradientFill '
       serialized_attributes str
       str << '>'

--- a/lib/axlsx/stylesheet/gradient_stop.rb
+++ b/lib/axlsx/stylesheet/gradient_stop.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # The GradientStop object represents a color point in a gradient.
   # @see Open Office XML Part 1 §18.8.24
@@ -28,7 +29,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << "<stop position=\"#{position}\">"
       self.color.to_xml_string(str)
       str << '</stop>'

--- a/lib/axlsx/stylesheet/gradient_stop.rb
+++ b/lib/axlsx/stylesheet/gradient_stop.rb
@@ -29,7 +29,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << ('<stop position="' << position.to_s << '">')
+      str << "<stop position=\"#{position}\">"
       self.color.to_xml_string(str)
       str << '</stop>'
     end

--- a/lib/axlsx/stylesheet/num_fmt.rb
+++ b/lib/axlsx/stylesheet/num_fmt.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # A NumFmt object defines an identifier and formatting code for data in cells.
   # @note The recommended way to manage styles is Styles#add_style
@@ -69,12 +70,12 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       serialized_tag('numFmt', str)
     end
 
     # Override to avoid removing underscores
-    def serialized_attributes(str = '', additional_attributes = {})
+    def serialized_attributes(str = String.new, additional_attributes = {})
       attributes = declared_attributes.merge! additional_attributes
       attributes.each do |key, value|
         str << "#{Axlsx.camel(key, false)}=\"#{Axlsx.booleanize(value)}\" "

--- a/lib/axlsx/stylesheet/pattern_fill.rb
+++ b/lib/axlsx/stylesheet/pattern_fill.rb
@@ -59,7 +59,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << ('<patternFill patternType="' << patternType.to_s << '">')
+      str << "<patternFill patternType=\"#{patternType}\">"
       if fgColor.is_a?(Color)
         fgColor.to_xml_string str, "fgColor"
       end

--- a/lib/axlsx/stylesheet/pattern_fill.rb
+++ b/lib/axlsx/stylesheet/pattern_fill.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # A PatternFill is the pattern and solid fill styling for a cell.
   # @note The recommended way to manage styles is with Styles#add_style
@@ -58,7 +59,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << "<patternFill patternType=\"#{patternType}\">"
       if fgColor.is_a?(Color)
         fgColor.to_xml_string str, "fgColor"

--- a/lib/axlsx/stylesheet/styles.rb
+++ b/lib/axlsx/stylesheet/styles.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   require 'axlsx/stylesheet/border.rb'
   require 'axlsx/stylesheet/border_pr.rb'
@@ -361,7 +362,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << "<styleSheet xmlns=\"#{XML_NS}\">"
       [:numFmts, :fonts, :fills, :borders, :cellStyleXfs, :cellXfs, :cellStyles, :dxfs, :tableStyles].each do |key|
         self.instance_values[key.to_s].to_xml_string(str) unless self.instance_values[key.to_s].nil?

--- a/lib/axlsx/stylesheet/styles.rb
+++ b/lib/axlsx/stylesheet/styles.rb
@@ -133,7 +133,7 @@ module Axlsx
     # @option options [Integer] family The font family to use.
     # @option options [String] font_name The name of the font to use
     # @option options [Integer] num_fmt The number format to apply
-    # @option options [String] format_code The formatting to apply. 
+    # @option options [String] format_code The formatting to apply.
     # @option options [Integer|Hash] border The border style to use.
     #   borders support style, color and edges options @see parse_border_options
     # @option options [String] bg_color The background color to apply to the cell
@@ -305,12 +305,12 @@ module Axlsx
 
     # parses Style#add_style options for borders.
     # @note noop if :border is not specified in options
-    # @option options [Hash|Integer] A border style definition hash or the index of an existing border. 
-    # Border style definition hashes must include :style and :color key-value entries and 
-    # may include an :edges entry that references an array of symbols identifying which border edges 
+    # @option options [Hash|Integer] A border style definition hash or the index of an existing border.
+    # Border style definition hashes must include :style and :color key-value entries and
+    # may include an :edges entry that references an array of symbols identifying which border edges
     # you wish to apply the style or any other valid Border initializer options.
     # If the :edges entity is not provided the style is applied to all edges of cells that reference this style.
-	# Also available :border_top, :border_right, :border_bottom and :border_left options with :style and/or :color 
+	# Also available :border_top, :border_right, :border_bottom and :border_left options with :style and/or :color
 	# key-value entries, which override :border values.
     # @example
     #   #apply a thick red border to the top and bottom
@@ -362,7 +362,7 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << ('<styleSheet xmlns="' << XML_NS << '">')
+      str << "<styleSheet xmlns=\"#{XML_NS}\">"
       [:numFmts, :fonts, :fills, :borders, :cellStyleXfs, :cellXfs, :cellStyles, :dxfs, :tableStyles].each do |key|
         self.instance_values[key.to_s].to_xml_string(str) unless self.instance_values[key.to_s].nil?
       end

--- a/lib/axlsx/stylesheet/table_style.rb
+++ b/lib/axlsx/stylesheet/table_style.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # A single table style definition and is a collection for tableStyleElements
   # @note Table are not supported in this version and only the defaults required for a valid workbook are created.
@@ -42,7 +43,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<tableStyle '
       serialized_attributes str, {:count => self.size}
       str << '>'

--- a/lib/axlsx/stylesheet/table_style_element.rb
+++ b/lib/axlsx/stylesheet/table_style_element.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # an element of style that belongs to a table style.
   # @note tables and table styles are not supported in this version. This class exists in preparation for that support.
@@ -69,7 +70,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       serialized_tag('tableStyleElement', str)
     end
 

--- a/lib/axlsx/stylesheet/table_styles.rb
+++ b/lib/axlsx/stylesheet/table_styles.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # TableStyles represents a collection of style definitions for table styles and pivot table styles.
   # @note Support for custom table styles does not exist in this version. Many of the classes required are defined in preparation for future release. Please do not attempt to add custom table styles.
@@ -33,7 +34,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<tableStyles '
       serialized_attributes str, {:count => self.size }
       str << '>'

--- a/lib/axlsx/stylesheet/xf.rb
+++ b/lib/axlsx/stylesheet/xf.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # The Xf class defines a formatting record for use in Styles. The recommended way to manage styles for your workbook is with Styles#add_style
   # @see Styles#add_style
@@ -133,7 +134,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<xf '
       serialized_attributes str
       str << '>'

--- a/lib/axlsx/util/accessors.rb
+++ b/lib/axlsx/util/accessors.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # This module defines some of the more common validating attribute
   # accessors that we use in Axlsx

--- a/lib/axlsx/util/constants.rb
+++ b/lib/axlsx/util/constants.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # XML Encoding

--- a/lib/axlsx/util/mime_type_utils.rb
+++ b/lib/axlsx/util/mime_type_utils.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # This module defines some utils related with mime type detection
   module MimeTypeUtils

--- a/lib/axlsx/util/options_parser.rb
+++ b/lib/axlsx/util/options_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # This module defines a single method for parsing options in class
   # initializers.

--- a/lib/axlsx/util/parser.rb
+++ b/lib/axlsx/util/parser.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # The Parser module mixes in a number of methods to help in generating a model from xml
   # This module is not included in the axlsx library at this time. It is for future development only,

--- a/lib/axlsx/util/serialized_attributes.rb
+++ b/lib/axlsx/util/serialized_attributes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # This module allows us to define a list of symbols defining which
   # attributes will be serialized for a class.
@@ -11,7 +12,7 @@ module Axlsx
     # class methods applied to all includers
     module ClassMethods
 
-      # This is the method to be used in inheriting classes to specify 
+      # This is the method to be used in inheriting classes to specify
       # which of the instance values are serializable
       def serializable_attributes(*symbols)
         @xml_attributes = symbols
@@ -43,13 +44,13 @@ module Axlsx
       end
     end
 
-    # serializes the instance values of the defining object based on the 
+    # serializes the instance values of the defining object based on the
     # list of serializable attributes.
     # @param [String] str The string instance to append this
     # serialization to.
     # @param [Hash] additional_attributes An option key value hash for
     # defining values that are not serializable attributes list.
-    def serialized_attributes(str = '', additional_attributes = {})
+    def serialized_attributes(str = String.new, additional_attributes = {})
       attributes = declared_attributes.merge! additional_attributes
       attributes.each do |key, value|
         str << "#{Axlsx.camel(key, false)}=\"#{Axlsx.camel(Axlsx.booleanize(value), false)}\" "
@@ -73,7 +74,7 @@ module Axlsx
     # @param [String] str The string instance to which serialized data is appended
     # @param [Array] additional_attributes An array of additional attribute names.
     # @return [String] The serialized output.
-    def serialized_element_attributes(str='', additional_attributes=[], &block)
+    def serialized_element_attributes(str = String.new, additional_attributes = [], &block)
       attrs = self.class.xml_element_attributes + additional_attributes
       values = instance_values
       attrs.each do |attribute_name|

--- a/lib/axlsx/util/simple_typed_list.rb
+++ b/lib/axlsx/util/simple_typed_list.rb
@@ -55,7 +55,7 @@ module Axlsx
       end
       result
     end
-    
+
     # Lock this list at the current size
     # @return [self]
     def lock
@@ -69,7 +69,7 @@ module Axlsx
       @locked_at = nil
       self
     end
-    
+
     def to_ary
       @list
     end
@@ -82,9 +82,9 @@ module Axlsx
     # one of the allowed types
     # @return [SimpleTypedList]
     def +(v)
-      v.each do |item| 
+      v.each do |item|
         DataTypeValidator.validate :SimpleTypedList_plus, @allowed_types, item
-        @list << item 
+        @list << item
       end
     end
 
@@ -96,10 +96,10 @@ module Axlsx
       DataTypeValidator.validate :SimpleTypedList_push, @allowed_types, v
       @list << v
       @list.size - 1
-    end 
-    
+    end
+
     alias :push :<<
-    
+
 
     # delete the item from the list
     # @param [Any] v The item to be deleted.
@@ -164,13 +164,13 @@ module Axlsx
         end
       }
     end
-                   
+
     def to_xml_string(str = '')
       classname = @allowed_types[0].name.split('::').last
       el_name = serialize_as.to_s || (classname[0,1].downcase + classname[1..-1])
-      str << ('<' << el_name << ' count="' << size.to_s << '">')
+      str << "<#{el_name} count=\"#{size}\">"
       each { |item| item.to_xml_string(str) }
-      str << ('</' << el_name << '>')
+      str << "</#{el_name}>"
     end
 
   end

--- a/lib/axlsx/util/simple_typed_list.rb
+++ b/lib/axlsx/util/simple_typed_list.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # A SimpleTypedList is a type restrictive collection that allows some of the methods from Array and supports basic xml serialization.
@@ -165,7 +166,7 @@ module Axlsx
       }
     end
 
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       classname = @allowed_types[0].name.split('::').last
       el_name = serialize_as.to_s || (classname[0,1].downcase + classname[1..-1])
       str << "<#{el_name} count=\"#{size}\">"

--- a/lib/axlsx/util/storage.rb
+++ b/lib/axlsx/util/storage.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # The Storage class represents a storage object or stream in a compound file.

--- a/lib/axlsx/util/validators.rb
+++ b/lib/axlsx/util/validators.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # Validate a value against a specific list of allowed values.
   class RestrictionValidator

--- a/lib/axlsx/version.rb
+++ b/lib/axlsx/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # The current version

--- a/lib/axlsx/workbook/defined_name.rb
+++ b/lib/axlsx/workbook/defined_name.rb
@@ -120,9 +120,9 @@ module Axlsx
 
     def to_xml_string(str='')
       raise ArgumentError, 'you must specify the name for this defined name. Please read the documentation for Axlsx::DefinedName for more details' unless name
-      str << ('<definedName ' << 'name="' << name << '" ')
+      str << "<definedName name=\"#{name}\" "
       serialized_attributes str
-      str << ('>' << @formula << '</definedName>')
+      str << ">#{@formula}</definedName>"
     end
   end
 end

--- a/lib/axlsx/workbook/defined_name.rb
+++ b/lib/axlsx/workbook/defined_name.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #  <definedNames>
 #    <definedName name="_xlnm.Print_Titles" localSheetId="0">Sheet1!$1:$1</definedName>
 #  </definedNames>
@@ -118,7 +119,7 @@ module Axlsx
     serializable_attributes :short_cut_key, :status_bar, :help, :description, :custom_menu, :comment,
       :workbook_parameter, :publish_to_server, :xlm, :vb_proceedure, :function, :hidden, :local_sheet_id
 
-    def to_xml_string(str='')
+    def to_xml_string(str = String.new)
       raise ArgumentError, 'you must specify the name for this defined name. Please read the documentation for Axlsx::DefinedName for more details' unless name
       str << "<definedName name=\"#{name}\" "
       serialized_attributes str

--- a/lib/axlsx/workbook/defined_names.rb
+++ b/lib/axlsx/workbook/defined_names.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # a simple types list of DefinedName objects
   class DefinedNames < SimpleTypedList
@@ -10,7 +11,7 @@ module Axlsx
     # Serialize to xml
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       return if empty?
       str << '<definedNames>'
       each { |defined_name| defined_name.to_xml_string(str) }

--- a/lib/axlsx/workbook/shared_strings_table.rb
+++ b/lib/axlsx/workbook/shared_strings_table.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # The Shared String Table class is responsible for managing and serializing common strings in a workbook.
@@ -37,7 +38,7 @@ module Axlsx
       @index = 0
       @xml_space = xml_space
       @unique_cells = {}
-      @shared_xml_string = ""
+      @shared_xml_string = String.new
       shareable_cells = cells.flatten.select{ |cell| cell.plain_string? || cell.contains_rich_text? }
       @count = shareable_cells.size
       resolve(shareable_cells)
@@ -46,7 +47,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str='')
+    def to_xml_string(str = String.new)
       Axlsx::sanitize(@shared_xml_string)
       str << "<?xml version=\"1.0\" encoding=\"UTF-8\"?><sst xmlns=\"#{XML_NS}\""\
              " count=\"#{@count}\" uniqueCount=\"#{unique_count}\""\

--- a/lib/axlsx/workbook/shared_strings_table.rb
+++ b/lib/axlsx/workbook/shared_strings_table.rb
@@ -48,9 +48,9 @@ module Axlsx
     # @return [String]
     def to_xml_string(str='')
       Axlsx::sanitize(@shared_xml_string)
-      str << ('<?xml version="1.0" encoding="UTF-8"?><sst xmlns="' << XML_NS << '"')
-      str << (' count="' << @count.to_s << '" uniqueCount="' << unique_count.to_s << '"')
-      str << (' xml:space="' << xml_space.to_s << '">' << @shared_xml_string << '</sst>')
+      str << "<?xml version=\"1.0\" encoding=\"UTF-8\"?><sst xmlns=\"#{XML_NS}\""\
+             " count=\"#{@count}\" uniqueCount=\"#{unique_count}\""\
+             " xml:space=\"#{xml_space}\">#{@shared_xml_string}</sst>"
     end
 
     private
@@ -67,7 +67,7 @@ module Axlsx
           cell.send :ssti=, index
         else
           cell.send :ssti=, @index
-          @shared_xml_string << '<si>' << CellSerializer.run_xml_string(cell) << '</si>'
+          @shared_xml_string << "<si>#{CellSerializer.run_xml_string(cell)}</si>"
           @unique_cells[cell_hash] = @index
           @index += 1
         end

--- a/lib/axlsx/workbook/workbook.rb
+++ b/lib/axlsx/workbook/workbook.rb
@@ -353,9 +353,9 @@ require 'axlsx/workbook/worksheet/selection.rb'
     # @return [String]
     def to_xml_string(str='')
       add_worksheet(name: 'Sheet1') unless worksheets.size > 0
-      str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << ('<workbook xmlns="' << XML_NS << '" xmlns:r="' << XML_NS_R << '">')
-      str << ('<workbookPr date1904="' << @@date1904.to_s << '"/>')
+      str << '<?xml version="1.0" encoding="UTF-8"?>'\
+             "<workbook xmlns=\"#{XML_NS}\" xmlns:r=\"#{XML_NS_R}\">"\
+             "<workbookPr date1904=\"#{@@date1904}\"/>"
       views.to_xml_string(str)
       str << '<sheets>'
       if is_reversed
@@ -368,7 +368,7 @@ require 'axlsx/workbook/worksheet/selection.rb'
       unless pivot_tables.empty?
         str << '<pivotCaches>'
         pivot_tables.each do |pivot_table|
-          str << ('<pivotCache cacheId="' << pivot_table.cache_definition.cache_id.to_s << '" r:id="' << pivot_table.cache_definition.rId << '"/>')
+          str << "<pivotCache cacheId=\"#{pivot_table.cache_definition.cache_id}\" r:id=\"#{pivot_table.cache_definition.rId}\"/>"
         end
         str << '</pivotCaches>'
       end

--- a/lib/axlsx/workbook/workbook.rb
+++ b/lib/axlsx/workbook/workbook.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 module Axlsx
 require 'axlsx/workbook/worksheet/sheet_calc_pr.rb'
 require 'axlsx/workbook/worksheet/auto_filter/auto_filter.rb'
@@ -351,7 +352,7 @@ require 'axlsx/workbook/worksheet/selection.rb'
     # Serialize the workbook
     # @param [String] str
     # @return [String]
-    def to_xml_string(str='')
+    def to_xml_string(str = String.new)
       add_worksheet(name: 'Sheet1') unless worksheets.size > 0
       str << '<?xml version="1.0" encoding="UTF-8"?>'\
              "<workbook xmlns=\"#{XML_NS}\" xmlns:r=\"#{XML_NS_R}\">"\

--- a/lib/axlsx/workbook/workbook_view.rb
+++ b/lib/axlsx/workbook/workbook_view.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # <xsd:complexType name="CT_BookView">
 #     <xsd:sequence>
 #       <xsd:element name="extLst" type="CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
@@ -71,7 +72,7 @@ module Axlsx
     # Serialize the WorkbookView
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
        str << '<workbookView '
        serialized_attributes str
        str << '></workbookView>'

--- a/lib/axlsx/workbook/workbook_views.rb
+++ b/lib/axlsx/workbook/workbook_views.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # a simple types list of BookView objects
   class WorkbookViews < SimpleTypedList
@@ -10,7 +11,7 @@ module Axlsx
     # Serialize to xml
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       return if empty?
       str << "<bookViews>"
       each { |view| view.to_xml_string(str) }

--- a/lib/axlsx/workbook/worksheet/auto_filter/auto_filter.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/auto_filter.rb
@@ -1,4 +1,5 @@
 
+# frozen_string_literal: true
 require 'axlsx/workbook/worksheet/auto_filter/filter_column.rb'
 require 'axlsx/workbook/worksheet/auto_filter/filters.rb'
 
@@ -66,7 +67,7 @@ module Axlsx
     end
     # serialize the object
     # @return [String]
-    def to_xml_string(str='')
+    def to_xml_string(str = String.new)
       return unless range
       str << "<autoFilter ref='#{range}'>"
       columns.each { |filter_column| filter_column.to_xml_string(str) }

--- a/lib/axlsx/workbook/worksheet/auto_filter/filter_column.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/filter_column.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # The filterColumn collection identifies a particular column in the AutoFilter
   # range and specifies filter information that has been applied to this column.
@@ -85,7 +86,7 @@ module Axlsx
     end
 
     # Serialize the object to xml
-    def to_xml_string(str='')
+    def to_xml_string(str = String.new)
       str << "<filterColumn #{serialized_attributes}>"
       @filter.to_xml_string(str)
       str << "</filterColumn>"

--- a/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
+++ b/lib/axlsx/workbook/worksheet/auto_filter/filters.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # When multiple values are chosen to filter by, or when a group of date values are chosen to filter by, 
@@ -74,7 +75,7 @@ module Axlsx
     end
 
     # Serialize the object to xml
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << "<filters #{serialized_attributes}>"
       filter_items.each {  |filter| filter.to_xml_string(str) }
       date_group_items.each { |date_group_item| date_group_item.to_xml_string(str) }
@@ -119,7 +120,7 @@ module Axlsx
 
       # Serializes the filter value object
       # @param [String] str The string to concact the serialization information to.
-      def to_xml_string(str = '')
+      def to_xml_string(str = String.new)
         str << "<filter val='#{@val.to_s}' />"
       end
     end
@@ -236,7 +237,7 @@ include Axlsx::SerializedAttributes
 
       # Serialize the object to xml
       # @param [String] str The string object this serialization will be concatenated to.
-      def to_xml_string(str = '')
+      def to_xml_string(str = String.new)
         serialized_tag('dateGroupItem', str)
       end
     end

--- a/lib/axlsx/workbook/worksheet/break.rb
+++ b/lib/axlsx/workbook/worksheet/break.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # The Break class stores the details for row and column page breaks.
@@ -27,7 +28,7 @@ module Axlsx
     serializable_attributes :id, :min, :max, :man, :pt
 
     # serializes the break to xml
-    def to_xml_string(str='')
+    def to_xml_string(str = String.new)
       serialized_tag('brk', str)
     end
   end

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -328,7 +328,8 @@ module Axlsx
     end
 
     def is_array_formula?
-      type == :string && @value.to_s.start_with?('{=') && @value.to_s.end_with?('}')
+      value = @value.to_s
+      type == :string && value.start_with?('{=') && value.end_with?('}')
     end
 
     # returns the absolute or relative string style reference for

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 require 'cgi'
 module Axlsx
   # A cell in a worksheet.
@@ -319,7 +320,7 @@ module Axlsx
     # @param [Integer] c_index The cell index in the row.
     # @param [String] str The string index the cell content will be appended to. Defaults to empty string.
     # @return [String] xml text for the cell
-    def to_xml_string(r_index, c_index, str = '')
+    def to_xml_string(r_index, c_index, str = String.new)
       CellSerializer.to_xml_string r_index, c_index, self, str
     end
 

--- a/lib/axlsx/workbook/worksheet/cell_serializer.rb
+++ b/lib/axlsx/workbook/worksheet/cell_serializer.rb
@@ -8,8 +8,8 @@ module Axlsx
       # @param [Integer] column_index The index of the cell's column
       # @param [String] str The string to apend serialization to.
       # @return [String]
-      def to_xml_string(row_index, column_index, cell, str='')
-        str << ('<c r="' << Axlsx::cell_r(column_index, row_index) << '" s="' << cell.style.to_s << '" ')
+      def to_xml_string(row_index, column_index, cell, str = '')
+        str << "<c r=\"#{Axlsx::cell_r(column_index, row_index)}\" s=\"#{cell.style}\" "
         return str << '/>' if cell.value.nil?
         method = cell.type
         self.send(method, cell, str)
@@ -28,7 +28,7 @@ module Axlsx
         elsif cell.contains_rich_text?
           cell.value.to_xml_string(str)
         else
-          str << ('<t>' << cell.clean_value << '</t>')
+          str << "<t>#{cell.clean_value}</t>"
         end
         str
       end
@@ -37,7 +37,7 @@ module Axlsx
       # @param [Cell] cell The cell that is being serialized
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
-      def iso_8601(cell, str='')
+      def iso_8601(cell, str = '')
         value_serialization 'd', cell.value, str
       end
 
@@ -86,8 +86,8 @@ module Axlsx
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
       def formula_serialization(cell, str='')
-        str << ('t="str"><f>' << cell.clean_value.to_s.sub('=', '') << '</f>')
-        str << ('<v>' << cell.formula_value.to_s << '</v>') unless cell.formula_value.nil?
+        str << "t=\"str\"><f>#{cell.clean_value.to_s.sub('=', '')}</f>"
+        str << "<v>#{cell.formula_value}</v>" unless cell.formula_value.nil?
       end
 
       # Serializes cells that are type array formula
@@ -95,8 +95,8 @@ module Axlsx
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
       def array_formula_serialization(cell, str='')
-        str << ('t="str">' << '<f t="array" ref="' << cell.r << '">' << cell.clean_value.to_s.sub('{=', '').sub(/}$/, '') << '</f>')
-        str << ('<v>' << cell.formula_value.to_s << '</v>') unless cell.formula_value.nil?
+        clean_value = cell.clean_value.to_s.sub('{=', ''); clean_value.sub!(/}$/, ''); str << "t=\"str\"><f t=\"array\" ref=\"#{cell.r}\">#{clean_value}</f>"
+        str << "<v>#{cell.formula_value}</v>" unless cell.formula_value.nil?
       end
 
       # Serializes cells that are type inline_string
@@ -156,8 +156,8 @@ module Axlsx
       end
 
       def value_serialization(serialization_type, serialization_value, str = '')
-        str << ('t="' << serialization_type.to_s << '"') if serialization_type
-        str << ('><v>' << serialization_value.to_s << '</v>')
+        str << "t=\"#{serialization_type}\"" if serialization_type
+        str << "><v>#{serialization_value}</v>"
       end
     end
   end

--- a/lib/axlsx/workbook/worksheet/cell_serializer.rb
+++ b/lib/axlsx/workbook/worksheet/cell_serializer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # The Cell Serializer class contains the logic for serializing cells based on their type.
@@ -8,7 +9,7 @@ module Axlsx
       # @param [Integer] column_index The index of the cell's column
       # @param [String] str The string to apend serialization to.
       # @return [String]
-      def to_xml_string(row_index, column_index, cell, str = '')
+      def to_xml_string(row_index, column_index, cell, str = String.new)
         str << "<c r=\"#{Axlsx::cell_r(column_index, row_index)}\" s=\"#{cell.style}\" "
         return str << '/>' if cell.value.nil?
         method = cell.type
@@ -19,7 +20,7 @@ module Axlsx
       # builds an xml text run based on this cells attributes.
       # @param [String] str The string instance this run will be concated to.
       # @return [String]
-      def run_xml_string(cell, str = '')
+      def run_xml_string(cell, str = String.new)
         if cell.is_text_run?
           valid = RichTextRun::INLINE_STYLES - [:value, :type]
           data = Hash[cell.instance_values.map{ |k, v| [k.to_sym, v] }]
@@ -37,7 +38,7 @@ module Axlsx
       # @param [Cell] cell The cell that is being serialized
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
-      def iso_8601(cell, str = '')
+      def iso_8601(cell, str = String.new)
         value_serialization 'd', cell.value, str
       end
 
@@ -45,7 +46,7 @@ module Axlsx
       # @param [Cell] cell The cell that is being serialized
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
-      def date(cell, str='')
+      def date(cell, str = String.new)
         value_serialization false, DateTimeConverter::date_to_serial(cell.value).to_s, str
       end
 
@@ -53,7 +54,7 @@ module Axlsx
       # @param [Cell] cell The cell that is being serialized
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
-      def time(cell, str='')
+      def time(cell, str = String.new)
         value_serialization false, DateTimeConverter::time_to_serial(cell.value).to_s, str
       end
 
@@ -61,7 +62,7 @@ module Axlsx
       # @param [Cell] cell The cell that is being serialized
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
-      def boolean(cell, str='')
+      def boolean(cell, str = String.new)
         value_serialization 'b', cell.value.to_s, str
       end
 
@@ -69,7 +70,7 @@ module Axlsx
       # @param [Cell] cell The cell that is being serialized
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
-      def float(cell, str='')
+      def float(cell, str = String.new)
         numeric cell, str
       end
 
@@ -77,7 +78,7 @@ module Axlsx
       # @param [Cell] cell The cell that is being serialized
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
-      def integer(cell, str = '')
+      def integer(cell, str = String.new)
         numeric cell, str
       end
 
@@ -85,7 +86,7 @@ module Axlsx
       # @param [Cell] cell The cell that is being serialized
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
-      def formula_serialization(cell, str='')
+      def formula_serialization(cell, str = String.new)
         str << "t=\"str\"><f>#{cell.clean_value.to_s.sub('=', '')}</f>"
         str << "<v>#{cell.formula_value}</v>" unless cell.formula_value.nil?
       end
@@ -94,7 +95,7 @@ module Axlsx
       # @param [Cell] cell The cell that is being serialized
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
-      def array_formula_serialization(cell, str='')
+      def array_formula_serialization(cell, str = String.new)
         clean_value = cell.clean_value.to_s.sub('{=', ''); clean_value.sub!(/}$/, ''); str << "t=\"str\"><f t=\"array\" ref=\"#{cell.r}\">#{clean_value}</f>"
         str << "<v>#{cell.formula_value}</v>" unless cell.formula_value.nil?
       end
@@ -103,7 +104,7 @@ module Axlsx
       # @param [Cell] cell The cell that is being serialized
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
-      def inline_string_serialization(cell, str = '')
+      def inline_string_serialization(cell, str = String.new)
         str << 't="inlineStr"><is>'
         run_xml_string cell, str
         str << '</is>'
@@ -113,7 +114,7 @@ module Axlsx
       # @param [Cell] cell The cell that is being serialized
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
-      def string(cell, str='')
+      def string(cell, str = String.new)
         if cell.is_array_formula?
           array_formula_serialization cell, str
         elsif cell.is_formula?
@@ -151,11 +152,11 @@ module Axlsx
 
       private
 
-      def numeric(cell, str = '')
+      def numeric(cell, str = String.new)
         value_serialization 'n', cell.value, str
       end
 
-      def value_serialization(serialization_type, serialization_value, str = '')
+      def value_serialization(serialization_type, serialization_value, str = String.new)
         str << "t=\"#{serialization_type}\"" if serialization_type
         str << "><v>#{serialization_value}</v>"
       end

--- a/lib/axlsx/workbook/worksheet/cfvo.rb
+++ b/lib/axlsx/workbook/worksheet/cfvo.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # Conditional Format Value Object
   # Describes the values of the interpolation points in a gradient scale. This object is used by ColorScale, DataBar and IconSet classes
@@ -53,7 +54,7 @@ module Axlsx
     # serialize the Csvo object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       serialized_tag('cfvo', str)
     end
   end

--- a/lib/axlsx/workbook/worksheet/cfvos.rb
+++ b/lib/axlsx/workbook/worksheet/cfvos.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   #A collection of Cfvo objects that initializes with the required
@@ -11,7 +12,7 @@ module Axlsx
     # Serialize the Cfvo object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str='')
+    def to_xml_string(str = String.new)
       each { |cfvo| cfvo.to_xml_string(str) }
     end
   end

--- a/lib/axlsx/workbook/worksheet/col.rb
+++ b/lib/axlsx/workbook/worksheet/col.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # The Col class defines column attributes for columns in sheets.
@@ -133,7 +134,7 @@ module Axlsx
     # Serialize this columns data to an xml string
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       serialized_tag('col', str)
     end
 

--- a/lib/axlsx/workbook/worksheet/col_breaks.rb
+++ b/lib/axlsx/workbook/worksheet/col_breaks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # A collection of Brake objects.
@@ -25,7 +26,7 @@ module Axlsx
     # <colBreaks count="1" manualBreakCount="1">
     # <brk id="3" max="1048575" man="1"/>
     # </colBreaks>
-    def to_xml_string(str='')
+    def to_xml_string(str = String.new)
       return if empty?
       str << "<colBreaks count=\"#{size}\" manualBreakCount=\"#{size}\">"
       each { |brk| brk.to_xml_string(str) }

--- a/lib/axlsx/workbook/worksheet/col_breaks.rb
+++ b/lib/axlsx/workbook/worksheet/col_breaks.rb
@@ -1,7 +1,7 @@
 module Axlsx
 
   # A collection of Brake objects.
-  # Please do not use this class directly. Instead use 
+  # Please do not use this class directly. Instead use
   # Worksheet#add_break
   class ColBreaks < SimpleTypedList
 
@@ -12,7 +12,7 @@ module Axlsx
 
     # A column break specific helper for adding a break.
     # @param [Hash] options A list of options to pass into the Break object
-    # The max and man options are fixed, however any other valid option for 
+    # The max and man options are fixed, however any other valid option for
     # Break will be passed to the created break object.
     # @see Break
     def add_break(options)
@@ -27,7 +27,7 @@ module Axlsx
     # </colBreaks>
     def to_xml_string(str='')
       return if empty?
-      str << ('<colBreaks count="' << size.to_s << '" manualBreakCount="' << size.to_s << '">')
+      str << "<colBreaks count=\"#{size}\" manualBreakCount=\"#{size}\">"
       each { |brk| brk.to_xml_string(str) }
       str << '</colBreaks>'
     end

--- a/lib/axlsx/workbook/worksheet/color_scale.rb
+++ b/lib/axlsx/workbook/worksheet/color_scale.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # Conditional Format Rule color scale object
   # Describes a gradated color scale in this conditional formatting rule.
@@ -85,7 +86,7 @@ module Axlsx
     # Serialize this color_scale object data to an xml string
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<colorScale>'
       value_objects.to_xml_string(str)
       colors.each { |color| color.to_xml_string(str) }

--- a/lib/axlsx/workbook/worksheet/cols.rb
+++ b/lib/axlsx/workbook/worksheet/cols.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # The cols class manages the col object used to manage column widths.
@@ -13,7 +14,7 @@ module Axlsx
     # Serialize the Cols object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
      return if empty?
      str << '<cols>'
      each { |item| item.to_xml_string(str) }

--- a/lib/axlsx/workbook/worksheet/comment.rb
+++ b/lib/axlsx/workbook/worksheet/comment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # A comment is the text data for a comment
@@ -60,7 +61,7 @@ module Axlsx
     # serialize the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = "")
+    def to_xml_string(str = String.new)
       author = @comments.authors[author_index]
       str << "<comment ref=\"#{ref}\" authorId=\"#{author_index}\">"
       str << '<text>'

--- a/lib/axlsx/workbook/worksheet/comment.rb
+++ b/lib/axlsx/workbook/worksheet/comment.rb
@@ -62,16 +62,16 @@ module Axlsx
     # @return [String]
     def to_xml_string(str = "")
       author = @comments.authors[author_index]
-      str << ('<comment ref="' << ref << '" authorId="' << author_index.to_s << '">')
+      str << "<comment ref=\"#{ref}\" authorId=\"#{author_index}\">"
       str << '<text>'
       unless author.to_s == ""
-        str << '<r><rPr><b/><color indexed="81"/></rPr>'
-        str << ("<t>" << ::CGI.escapeHTML(author.to_s) << ":\n</t></r>")
+        str << '<r><rPr><b/><color indexed="81"/></rPr>'\
+               "<t>#{::CGI.escapeHTML(author.to_s)}:\n</t></r>"
       end
-      str << '<r>'
-      str << '<rPr><color indexed="81"/></rPr>'
-      str << ('<t>' << ::CGI.escapeHTML(text) << '</t></r></text>')
-      str << '</comment>'
+      str << '<r>'\
+             '<rPr><color indexed="81"/></rPr>'\
+             "<t>#{::CGI.escapeHTML(text)}</t></r></text>"\
+             '</comment>'
     end
 
     private
@@ -82,7 +82,7 @@ module Axlsx
       pos = Axlsx::name_to_indices(ref)
       @vml_shape = VmlShape.new(:row => pos[1], :column => pos[0], :visible => @visible) do |vml|
         vml.left_column = vml.column
-        vml.right_column = vml.column + 2 
+        vml.right_column = vml.column + 2
         vml.top_row = vml.row
          vml.bottom_row = vml.row + 4
       end

--- a/lib/axlsx/workbook/worksheet/comments.rb
+++ b/lib/axlsx/workbook/worksheet/comments.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 module Axlsx
 
   # Comments is a collection of Comment objects for a worksheet
@@ -63,7 +64,7 @@ module Axlsx
     # serialize the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str="")
+    def to_xml_string(str = String.new)
       str << '<?xml version="1.0" encoding="UTF-8"?>'
       str << "<comments xmlns=\"#{XML_NS}\"><authors>"
       authors.each do  |author|

--- a/lib/axlsx/workbook/worksheet/comments.rb
+++ b/lib/axlsx/workbook/worksheet/comments.rb
@@ -65,9 +65,9 @@ module Axlsx
     # @return [String]
     def to_xml_string(str="")
       str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << ('<comments xmlns="' << XML_NS << '"><authors>')
+      str << "<comments xmlns=\"#{XML_NS}\"><authors>"
       authors.each do  |author|
-        str << ('<author>' << author.to_s << '</author>')
+        str << "<author>#{author}</author>"
       end
       str << '</authors><commentList>'
       each do |comment|

--- a/lib/axlsx/workbook/worksheet/conditional_formatting.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # Conditional formatting allows styling of ranges based on functions
   #
@@ -73,7 +74,7 @@ module Axlsx
     #    </conditionalFormatting>
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << "<conditionalFormatting sqref=\"#{sqref}\">"
       rules.each { |rule| str << rule.to_xml_string }
       str << '</conditionalFormatting>'

--- a/lib/axlsx/workbook/worksheet/conditional_formatting.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting.rb
@@ -7,7 +7,7 @@ module Axlsx
   class ConditionalFormatting
 
    include Axlsx::OptionsParser
-   
+
     # Creates a new {ConditionalFormatting} object
     # @option options [Array] rules The rules to apply
     # @option options [String] sqref The range to apply the rules to
@@ -74,8 +74,8 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << ('<conditionalFormatting sqref="' << sqref << '">')
-      str << rules.collect{ |rule| rule.to_xml_string }.join(' ')
+      str << "<conditionalFormatting sqref=\"#{sqref}\">"
+      rules.each { |rule| str << rule.to_xml_string }
       str << '</conditionalFormatting>'
     end
   end

--- a/lib/axlsx/workbook/worksheet/conditional_formatting_rule.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting_rule.rb
@@ -210,7 +210,7 @@ module Axlsx
       str << '<cfRule '
       serialized_attributes str
       str << '>'
-      str << ('<formula>' << [*self.formula].join('</formula><formula>') << '</formula>') if @formula
+      str << "<formula>#{self.formula.join('</formula><formula>')}</formula>" if @formula
       @color_scale.to_xml_string(str) if @color_scale && @type == :colorScale
       @data_bar.to_xml_string(str) if @data_bar && @type == :dataBar
       @icon_set.to_xml_string(str) if @icon_set && @type == :iconSet

--- a/lib/axlsx/workbook/worksheet/conditional_formatting_rule.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formatting_rule.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 module Axlsx
   # Conditional formatting rules specify formulas whose evaluations
   # format cells
@@ -206,7 +207,7 @@ module Axlsx
     # Serializes the conditional formatting rule
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<cfRule '
       serialized_attributes str
       str << '>'

--- a/lib/axlsx/workbook/worksheet/conditional_formattings.rb
+++ b/lib/axlsx/workbook/worksheet/conditional_formattings.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # A simple, self serializing class for storing conditional formattings
@@ -15,7 +16,7 @@ module Axlsx
     attr_reader :worksheet
 
     # serialize the conditional formattings
-    def to_xml_string(str = "")
+    def to_xml_string(str = String.new)
       return if empty?
       each { |item| item.to_xml_string(str) }
     end

--- a/lib/axlsx/workbook/worksheet/data_bar.rb
+++ b/lib/axlsx/workbook/worksheet/data_bar.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # Conditional Format Rule data bar object
   # Describes a data bar conditional formatting rule.
@@ -106,7 +107,7 @@ module Axlsx
     # Serialize this object to an xml string
     # @param [String] str
     # @return [String]
-    def to_xml_string(str="")
+    def to_xml_string(str = String.new)
       serialized_tag('dataBar', str) do
         value_objects.to_xml_string(str)
         self.color.to_xml_string(str)

--- a/lib/axlsx/workbook/worksheet/data_validation.rb
+++ b/lib/axlsx/workbook/worksheet/data_validation.rb
@@ -171,7 +171,7 @@ module Axlsx
     def formula1=(v); Axlsx::validate_string(v); @formula1 = v end
 
     # @see formula2
-    def formula2=(v); Axlsx::validate_string(v); @formula2 = v end 
+    def formula2=(v); Axlsx::validate_string(v); @formula2 = v end
 
     # @see allowBlank
     def allowBlank=(v); Axlsx::validate_boolean(v); @allowBlank = v end
@@ -215,13 +215,13 @@ module Axlsx
     def to_xml_string(str = '')
       valid_attributes = get_valid_attributes
 
-      str << '<dataValidation '
-      str << instance_values.map do |key, value| 
-        '' << key << '="' << Axlsx.booleanize(value).to_s << '"' if (valid_attributes.include?(key.to_sym) && !CHILD_ELEMENTS.include?(key.to_sym)) 
-      end.join(' ')
+      str << '<dataValidation'
+      instance_values.each do |key, value|
+        str << " #{key}=\"#{Axlsx.booleanize(value)}\"" if (valid_attributes.include?(key.to_sym) && !CHILD_ELEMENTS.include?(key.to_sym))
+      end
       str << '>'
-      str << ('<formula1>' << self.formula1 << '</formula1>') if @formula1 and valid_attributes.include?(:formula1)
-      str << ('<formula2>' << self.formula2 << '</formula2>') if @formula2 and valid_attributes.include?(:formula2)
+      str << "<formula1>#{self.formula1}</formula1>" if @formula1 and valid_attributes.include?(:formula1)
+      str << "<formula2>#{self.formula2}</formula2>)" if @formula2 and valid_attributes.include?(:formula2)
       str << '</dataValidation>'
     end
 

--- a/lib/axlsx/workbook/worksheet/data_validation.rb
+++ b/lib/axlsx/workbook/worksheet/data_validation.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # Data validation allows the validation of cell data
   #
@@ -212,7 +213,7 @@ module Axlsx
     # Serializes the data validation
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       valid_attributes = get_valid_attributes
 
       str << '<dataValidation'

--- a/lib/axlsx/workbook/worksheet/data_validations.rb
+++ b/lib/axlsx/workbook/worksheet/data_validations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # A simple, self serializing class for storing conditional formattings
@@ -15,7 +16,7 @@ module Axlsx
     attr_reader :worksheet
 
     # serialize the conditional formattings
-    def to_xml_string(str = "")
+    def to_xml_string(str = String.new)
       return if empty?
       str << "<dataValidations count='#{size}'>"
       each { |item| item.to_xml_string(str) }

--- a/lib/axlsx/workbook/worksheet/date_time_converter.rb
+++ b/lib/axlsx/workbook/worksheet/date_time_converter.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 require "date"
 
 module Axlsx

--- a/lib/axlsx/workbook/worksheet/dimension.rb
+++ b/lib/axlsx/workbook/worksheet/dimension.rb
@@ -1,7 +1,7 @@
 module Axlsx
 
   # This class manages the dimensions for a worksheet.
-  # While this node is optional in the specification some readers like 
+  # While this node is optional in the specification some readers like
   # LibraOffice require this node to render the sheet
   class Dimension
 
@@ -31,13 +31,13 @@ module Axlsx
     # @return [String]
     def sqref
       "#{first_cell_reference}:#{last_cell_reference}"
-    end 
+    end
 
     # serialize the object
     # @return [String]
     def to_xml_string(str = '')
       return if worksheet.rows.empty?
-      str << "<dimension ref=\"%s\"></dimension>" % sqref
+      str << "<dimension ref=\"#{sqref}\"></dimension>"
     end
 
     # The first cell in the dimension

--- a/lib/axlsx/workbook/worksheet/dimension.rb
+++ b/lib/axlsx/workbook/worksheet/dimension.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # This class manages the dimensions for a worksheet.
@@ -35,7 +36,7 @@ module Axlsx
 
     # serialize the object
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       return if worksheet.rows.empty?
       str << "<dimension ref=\"#{sqref}\"></dimension>"
     end

--- a/lib/axlsx/workbook/worksheet/header_footer.rb
+++ b/lib/axlsx/workbook/worksheet/header_footer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # Header/Footer options for printing a worksheet. All settings are optional.
   #
@@ -41,7 +42,7 @@ module Axlsx
     # Serializes the header/footer object.
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       serialized_tag('headerFooter', str) do
         serialized_element_attributes(str) do |value|
           value = ::CGI.escapeHTML(value)

--- a/lib/axlsx/workbook/worksheet/icon_set.rb
+++ b/lib/axlsx/workbook/worksheet/icon_set.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # Conditional Format Rule icon sets
   # Describes an icon set conditional formatting rule.
@@ -62,7 +63,7 @@ module Axlsx
     # Serialize this object to an xml string
     # @param [String] str
     # @return [String]
-    def to_xml_string(str="")
+    def to_xml_string(str = String.new)
       serialized_tag('iconSet', str) do
         @value_objects.each { |cfvo| cfvo.to_xml_string(str) }
       end

--- a/lib/axlsx/workbook/worksheet/merged_cells.rb
+++ b/lib/axlsx/workbook/worksheet/merged_cells.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # A simple list of merged cells
@@ -27,7 +28,7 @@ module Axlsx
     # serialize the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       return if empty?
       str << "<mergeCells count='#{size}'>"
       each { |merged_cell| str << "<mergeCell ref='#{merged_cell}'></mergeCell>" }

--- a/lib/axlsx/workbook/worksheet/outline_pr.rb
+++ b/lib/axlsx/workbook/worksheet/outline_pr.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # The OutlinePr class manages serialization of a worksheet's outlinePr element, which provides various
@@ -26,7 +27,7 @@ module Axlsx
     # Serialize the object
     # @param [String] str serialized output will be appended to this object if provided.
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << "<outlinePr #{serialized_attributes} />"
     end
   end

--- a/lib/axlsx/workbook/worksheet/page_margins.rb
+++ b/lib/axlsx/workbook/worksheet/page_margins.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # PageMargins specify the margins when printing a worksheet.
   #
@@ -90,7 +91,7 @@ module Axlsx
     # @return [String]
     # @note For compatibility, this is a noop unless custom margins have been specified.
     # @see #custom_margins_specified?
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       serialized_tag('pageMargins', str)
     end
   end

--- a/lib/axlsx/workbook/worksheet/page_set_up_pr.rb
+++ b/lib/axlsx/workbook/worksheet/page_set_up_pr.rb
@@ -38,7 +38,7 @@ module Axlsx
 
     # serialize to xml
     def to_xml_string(str='')
-      str << ('<pageSetUpPr ' << serialized_attributes << '/>')
+      str << "<pageSetUpPr #{serialized_attributes}/>"
     end
   end
 end

--- a/lib/axlsx/workbook/worksheet/page_set_up_pr.rb
+++ b/lib/axlsx/workbook/worksheet/page_set_up_pr.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # Page setup properties of the worksheet
@@ -37,7 +38,7 @@ module Axlsx
     end
 
     # serialize to xml
-    def to_xml_string(str='')
+    def to_xml_string(str = String.new)
       str << "<pageSetUpPr #{serialized_attributes}/>"
     end
   end

--- a/lib/axlsx/workbook/worksheet/page_setup.rb
+++ b/lib/axlsx/workbook/worksheet/page_setup.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # Page setup settings for printing a worksheet. All settings are optional.
   #
@@ -233,7 +234,7 @@ module Axlsx
     # Serializes the page settings element.
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       serialized_tag('pageSetup', str)
     end
   end

--- a/lib/axlsx/workbook/worksheet/pane.rb
+++ b/lib/axlsx/workbook/worksheet/pane.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # Pane options for a worksheet.
   #
@@ -122,7 +123,7 @@ module Axlsx
     # Serializes the data validation
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       finalize
       serialized_tag 'pane', str
     end

--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # Table
   # @note Worksheet#add_pivot_table is the recommended way to create tables for your worksheets.
@@ -167,7 +168,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<?xml version="1.0" encoding="UTF-8"?>'\
              "<pivotTableDefinition xmlns=\"#{XML_NS}\" name=\"#{name}\" cacheId=\"#{cache_definition.cache_id}\" "\
              "dataOnRows=\"1\" applyNumberFormats=\"0\" applyBorderFormats=\"0\" applyFontFormats=\"0\" "\

--- a/lib/axlsx/workbook/worksheet/pivot_table.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table.rb
@@ -168,24 +168,28 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << ('<pivotTableDefinition xmlns="' << XML_NS << '" name="' << name << '" cacheId="' << cache_definition.cache_id.to_s << '"  dataOnRows="1" applyNumberFormats="0" applyBorderFormats="0" applyFontFormats="0" applyPatternFormats="0" applyAlignmentFormats="0" applyWidthHeightFormats="1" dataCaption="Data" showMultipleLabel="0" showMemberPropertyTips="0" useAutoFormatting="1" indent="0" compact="0" compactData="0" gridDropZones="1" multipleFieldFilters="0">')
-      str << ('<location firstDataCol="1" firstDataRow="1" firstHeaderRow="1" ref="' << ref << '"/>')
-      str << ('<pivotFields count="' << header_cells_count.to_s << '">')
+      str << '<?xml version="1.0" encoding="UTF-8"?>'\
+             "<pivotTableDefinition xmlns=\"#{XML_NS}\" name=\"#{name}\" cacheId=\"#{cache_definition.cache_id}\" "\
+             "dataOnRows=\"1\" applyNumberFormats=\"0\" applyBorderFormats=\"0\" applyFontFormats=\"0\" "\
+             "applyPatternFormats=\"0\" applyAlignmentFormats=\"0\" applyWidthHeightFormats=\"1\" dataCaption=\"Data\" "\
+             "showMultipleLabel=\"0\" showMemberPropertyTips=\"0\" useAutoFormatting=\"1\" indent=\"0\" compact=\"0\" "\
+             "compactData=\"0\" gridDropZones=\"1\" multipleFieldFilters=\"0\">"\
+             "<location firstDataCol=\"1\" firstDataRow=\"1\" firstHeaderRow=\"1\" ref=\"#{ref}\"/>"\
+             "<pivotFields count=\"#{header_cells_count}\">"
       header_cell_values.each do |cell_value|
         str << pivot_field_for(cell_value, !no_subtotals_on_headers.include?(cell_value))
       end
       str << '</pivotFields>'
       if rows.empty?
-        str << '<rowFields count="1"><field x="-2"/></rowFields>'
-        str << '<rowItems count="2"><i><x/></i> <i i="1"><x v="1"/></i></rowItems>'
+        str << '<rowFields count="1"><field x="-2"/></rowFields>'\
+               '<rowItems count="2"><i><x/></i> <i i="1"><x v="1"/></i></rowItems>'
       else
-        str << ('<rowFields count="' << rows.size.to_s << '">')
+        str << "<rowFields count=\"#{rows.size}\">"
         rows.each do |row_value|
-          str << ('<field x="' << header_index_of(row_value).to_s << '"/>')
+          str << "<field x=\"#{header_index_of(row_value)}\"/>"
         end
-        str << '</rowFields>'
-        str << ('<rowItems count="' << rows.size.to_s << '">')
+        str << '</rowFields>'\
+               "<rowItems count=\"#{rows.size}\">"
         rows.size.times do |i|
           str << '<i/>'
         end
@@ -194,16 +198,16 @@ module Axlsx
       if columns.empty?
         str << '<colItems count="1"><i/></colItems>'
       else
-        str << ('<colFields count="' << columns.size.to_s << '">')
+        str << "<colFields count=\"#{columns.size}\">"
         columns.each do |column_value|
-          str << ('<field x="' << header_index_of(column_value).to_s << '"/>')
+          str << "<field x=\"#{header_index_of(column_value)}\"/>"
         end
         str << '</colFields>'
       end
       unless pages.empty?
-        str << ('<pageFields count="' << pages.size.to_s << '">')
+        str << "<pageFields count=\"#{pages.size}\">"
         pages.each do |page_value|
-          str << ('<pageField fld="' << header_index_of(page_value).to_s << '"/>')
+          str << "<pageField fld=\"#{header_index_of(page_value)}\"/>"
         end
         str << '</pageFields>'
       end
@@ -221,7 +225,7 @@ module Axlsx
       unless style_info.empty?
         str << '<pivotTableStyleInfo'
         style_info.each do |k,v|
-          str << ' ' << k.to_s << '="' << v.to_s << '"'
+          str << " #{k}=\"#{v}\""
         end
         str << ' />'
       end

--- a/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
@@ -46,20 +46,20 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << ('<pivotCacheDefinition xmlns="' << XML_NS << '" xmlns:r="' << XML_NS_R << '" invalid="1" refreshOnLoad="1" recordCount="0">')
-      str <<   '<cacheSource type="worksheet">'
-      str << (    '<worksheetSource ref="' << pivot_table.range << '" sheet="' << pivot_table.data_sheet.name << '"/>')
-      str <<   '</cacheSource>'
-      str << (  '<cacheFields count="' << pivot_table.header_cells_count.to_s << '">')
+      str << '<?xml version="1.0" encoding="UTF-8"?>'\
+             "<pivotCacheDefinition xmlns=\"#{XML_NS}\" xmlns:r=\"#{XML_NS_R}\" invalid=\"1\" refreshOnLoad=\"1\" recordCount=\"0\">"\
+               '<cacheSource type="worksheet">'\
+                  "<worksheetSource ref=\"#{pivot_table.range}\" sheet=\"#{pivot_table.data_sheet.name}\"/>"\
+               '</cacheSource>'\
+                "<cacheFields count=\"#{pivot_table.header_cells_count}\">"
       pivot_table.header_cells.each do |cell|
-        str << (  '<cacheField name="' << cell.value << '" numFmtId="0">')
-        str <<     '<sharedItems count="0">'
-        str <<     '</sharedItems>'
-        str <<   '</cacheField>'
+        str <<   "<cacheField name=\"#{cell.value}\" numFmtId=\"0\">"\
+                   '<sharedItems count="0">'\
+                   '</sharedItems>'\
+                 '</cacheField>'
       end
-      str <<   '</cacheFields>'
-      str << '</pivotCacheDefinition>'
+      str <<   '</cacheFields>'\
+             '</pivotCacheDefinition>'
     end
 
   end

--- a/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_table_cache_definition.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # Table
   # @note Worksheet#add_pivot_table is the recommended way to create tables for your worksheets.
@@ -45,7 +46,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<?xml version="1.0" encoding="UTF-8"?>'\
              "<pivotCacheDefinition xmlns=\"#{XML_NS}\" xmlns:r=\"#{XML_NS_R}\" invalid=\"1\" refreshOnLoad=\"1\" recordCount=\"0\">"\
                '<cacheSource type="worksheet">'\

--- a/lib/axlsx/workbook/worksheet/pivot_tables.rb
+++ b/lib/axlsx/workbook/worksheet/pivot_tables.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # A simple, self serializing class for storing pivot tables

--- a/lib/axlsx/workbook/worksheet/print_options.rb
+++ b/lib/axlsx/workbook/worksheet/print_options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # Options for printing a worksheet. All options are boolean and false by default.
   #
@@ -32,7 +33,7 @@ module Axlsx
     # @note As all attributes default to "false" according to the xml schema definition, the generated xml includes only those attributes that are set to true.
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       serialized_tag 'printOptions', str
     end
   end

--- a/lib/axlsx/workbook/worksheet/protected_range.rb
+++ b/lib/axlsx/workbook/worksheet/protected_range.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
   # The Protected Range class represents a set of cells in the worksheet
   # @note the recommended way to manage protected ranges with via Worksheet#protect_range
@@ -40,8 +41,8 @@ module Axlsx
     # @param [String] str if this string object is provided we append
     # our output to that object. Use this - it helps limit the number of
     # objects created during serialization
-    def to_xml_string(str="")
+    def to_xml_string(str = String.new)
       serialized_tag 'protectedRange', str
-    end 
+    end
   end
 end

--- a/lib/axlsx/workbook/worksheet/protected_ranges.rb
+++ b/lib/axlsx/workbook/worksheet/protected_ranges.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # A self serializing collection of ranges that should be protected in
@@ -27,7 +28,7 @@ module Axlsx
     # Serializes the protected ranges
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       return if empty?
       str << '<protectedRanges>'
       each { |range| range.to_xml_string(str) }

--- a/lib/axlsx/workbook/worksheet/rich_text.rb
+++ b/lib/axlsx/workbook/worksheet/rich_text.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # A simple, self serializing class for storing TextRuns
@@ -47,7 +48,7 @@ module Axlsx
     # renders the RichTextRuns in this collection
     # @param [String] str
     # @return [String]
-    def to_xml_string(str='')
+    def to_xml_string(str = String.new)
       each{ |run| run.to_xml_string(str) }
       str
     end

--- a/lib/axlsx/workbook/worksheet/rich_text_run.rb
+++ b/lib/axlsx/workbook/worksheet/rich_text_run.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # The RichTextRun class creates and self serializing text run.
@@ -188,7 +189,7 @@ module Axlsx
     # Serializes the RichTextRun
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       valid = RichTextRun::INLINE_STYLES
       data = Hash[self.instance_values.map{ |k, v| [k.to_sym, v] }]
       data = data.select { |key, value| valid.include?(key) && !value.nil? }

--- a/lib/axlsx/workbook/worksheet/rich_text_run.rb
+++ b/lib/axlsx/workbook/worksheet/rich_text_run.rb
@@ -197,15 +197,15 @@ module Axlsx
       data.keys.each do |key|
         case key
         when :font_name
-          str << ('<rFont val="' << font_name << '"/>')
+          str << "<rFont val=\"#{font_name}\"/>"
         when :color
           str << data[key].to_xml_string
         else
-          str << ('<' << key.to_s << ' val="' << xml_value(data[key]) << '"/>')
+          str << "<#{key} val=\"#{xml_value(data[key])}\"/>"
         end
       end
       clean_value = Axlsx::trust_input ? @value.to_s : ::CGI.escapeHTML(Axlsx::sanitize(@value.to_s))
-      str << ('</rPr><t>' << clean_value << '</t></r>')
+      str << "</rPr><t>#{clean_value}</t></r>"
     end
 
     private

--- a/lib/axlsx/workbook/worksheet/row.rb
+++ b/lib/axlsx/workbook/worksheet/row.rb
@@ -6,7 +6,7 @@ module Axlsx
   class Row < SimpleTypedList
     include SerializedAttributes
     include Accessors
-    
+
     # No support is provided for the following attributes
     # spans
     # thickTop
@@ -63,7 +63,7 @@ module Axlsx
     # @see Row#s
     def s=(v)
       Axlsx.validate_unsigned_numeric(v)
-      @custom_format = true 
+      @custom_format = true
       @s = v
     end
 
@@ -72,7 +72,7 @@ module Axlsx
       Axlsx.validate_unsigned_numeric(v)
       @outline_level = v
     end
-    
+
     alias :outlineLevel= :outline_level=
 
     # The index of this row in the worksheet
@@ -87,8 +87,7 @@ module Axlsx
     # @return [String]
     def to_xml_string(r_index, str = '')
       serialized_tag('row', str, :r => r_index + 1) do
-        tmp = '' # time / memory tradeoff, lots of calls to rubyzip costs more
-                 # time..
+        tmp = String.new # time / memory tradeoff, lots of calls to rubyzip costs more time..
         each_with_index { |cell, c_index| cell.to_xml_string(r_index, c_index, tmp) }
         str << tmp
       end
@@ -125,7 +124,7 @@ module Axlsx
         @ht = v
       end
     end
-    
+
     # return cells
     def cells
       self

--- a/lib/axlsx/workbook/worksheet/row.rb
+++ b/lib/axlsx/workbook/worksheet/row.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # A Row is a single row in a worksheet.
   # @note The recommended way to manage rows and cells is to use Worksheet#add_row
@@ -85,7 +86,7 @@ module Axlsx
     # @param [Integer] r_index The row index, 0 based.
     # @param [String] str The string this rows xml will be appended to.
     # @return [String]
-    def to_xml_string(r_index, str = '')
+    def to_xml_string(r_index, str = String.new)
       serialized_tag('row', str, :r => r_index + 1) do
         tmp = String.new # time / memory tradeoff, lots of calls to rubyzip costs more time..
         each_with_index { |cell, c_index| cell.to_xml_string(r_index, c_index, tmp) }
@@ -95,7 +96,7 @@ module Axlsx
 
     # Adds a single cell to the row based on the data provided and updates the worksheet's autofit data.
     # @return [Cell]
-    def add_cell(value = '', options = {})
+    def add_cell(value = String.new, options = {})
       c = Cell.new(self, value, options)
       self << c
       worksheet.send(:update_column_info, self, [])

--- a/lib/axlsx/workbook/worksheet/row_breaks.rb
+++ b/lib/axlsx/workbook/worksheet/row_breaks.rb
@@ -17,7 +17,7 @@ module Axlsx
       self << Break.new(options.merge(:max => 16383, :man => true))
       last
     end
- 
+
     # <rowBreaks count="3" manualBreakCount="3">
     # <brk id="1" max="16383" man="1"/>
     # <brk id="7" max="16383" man="1"/>
@@ -25,7 +25,7 @@ module Axlsx
     # </rowBreaks>
     def to_xml_string(str='')
       return if empty?
-      str << ('<rowBreaks count="' << self.size.to_s << '" manualBreakCount="' << self.size.to_s << '">')
+      str << "<rowBreaks count=\"#{self.size}\" manualBreakCount=\"#{self.size}\">"
       each { |brk| brk.to_xml_string(str) }
       str << '</rowBreaks>'
     end

--- a/lib/axlsx/workbook/worksheet/row_breaks.rb
+++ b/lib/axlsx/workbook/worksheet/row_breaks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # A collection of break objects that define row breaks (page breaks) for printing and preview
@@ -23,7 +24,7 @@ module Axlsx
     # <brk id="7" max="16383" man="1"/>
     # <brk id="13" max="16383" man="1"/>
     # </rowBreaks>
-    def to_xml_string(str='')
+    def to_xml_string(str = String.new)
       return if empty?
       str << "<rowBreaks count=\"#{self.size}\" manualBreakCount=\"#{self.size}\">"
       each { |brk| brk.to_xml_string(str) }

--- a/lib/axlsx/workbook/worksheet/selection.rb
+++ b/lib/axlsx/workbook/worksheet/selection.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # Selection options for worksheet panes.
   #
@@ -94,7 +95,7 @@ module Axlsx
     # Serializes the data validation
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       serialized_tag 'selection', str
     end
   end

--- a/lib/axlsx/workbook/worksheet/sheet_calc_pr.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_calc_pr.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # the SheetCalcPr object for the worksheet
@@ -22,7 +23,7 @@ module Axlsx
     # @param [String] str the string to append this objects serialized
     # content to.
     # @return [String]
-    def to_xml_string(str='')
+    def to_xml_string(str = String.new)
       str << "<sheetCalcPr #{serialized_attributes}/>"
     end
   end

--- a/lib/axlsx/workbook/worksheet/sheet_data.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_data.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # This class manages the serialization of rows for worksheets
@@ -15,7 +16,7 @@ module Axlsx
     # Serialize the sheet data
     # @param [String] str the string this objects serializaton will be concacted to.
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<sheetData>'
       worksheet.rows.each_with_index do |row, index| 
         row.to_xml_string(index, str) 

--- a/lib/axlsx/workbook/worksheet/sheet_format_pr.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_format_pr.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   #Sheet formatting properties
@@ -47,7 +48,7 @@ module Axlsx
     # serializes this object to an xml string
     # @param [String] str The string this objects serialization will be appended to
     # @return [String]
-    def to_xml_string(str='')
+    def to_xml_string(str = String.new)
       str << "<sheetFormatPr #{serialized_attributes}/>"
     end
 

--- a/lib/axlsx/workbook/worksheet/sheet_pr.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_pr.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # The SheetPr class manages serialization of a worksheet's sheetPr element.
@@ -48,7 +49,7 @@ module Axlsx
     # Serialize the object
     # @param [String] str serialized output will be appended to this object if provided.
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       update_properties
       str << "<sheetPr #{serialized_attributes}>"
       tab_color.to_xml_string(str, 'tabColor') if tab_color

--- a/lib/axlsx/workbook/worksheet/sheet_protection.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_protection.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # The SheetProtection object manages worksheet protection options per sheet.
@@ -75,7 +76,7 @@ module Axlsx
     # Serialize the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       serialized_tag('sheetProtection', str)
     end
 

--- a/lib/axlsx/workbook/worksheet/sheet_view.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_view.rb
@@ -5,7 +5,7 @@ module Axlsx
   # @note The recommended way to manage the sheet view is via Worksheet#sheet_view
   # @see Worksheet#sheet_view
   class SheetView
-   
+
     include Axlsx::OptionsParser
     include Axlsx::Accessors
     include Axlsx::SerializedAttributes
@@ -66,11 +66,11 @@ module Axlsx
     # @return [Hash]
     attr_reader :selections
 
-    #  
+    #
     # Color Id
     # Index to the color value for row/column
-    # text headings and gridlines. This is an 
-    # 'index color value' (ICV) rather than 
+    # text headings and gridlines. This is an
+    # 'index color value' (ICV) rather than
     # rgb value.
     # @see type
     # @return [Integer]
@@ -78,18 +78,18 @@ module Axlsx
     attr_reader :color_id
 
     # Top Left Visible Cell
-    # Location of the top left visible cell Location 
+    # Location of the top left visible cell Location
     # of the top left visible cell in the bottom right
     # pane (when in Left-to-Right mode).
     # @see type
     # @return [String]
     # default nil
     attr_reader :top_left_cell
-    
-    
+
+
     # View Type
     # Indicates the view type.
-    # Options are 
+    # Options are
     #  * normal: Normal view
     #  * page_break_preview: Page break preview
     #  * page_layout: Page Layout View
@@ -99,62 +99,62 @@ module Axlsx
     attr_reader :view
 
     # Workbook View Index
-    # Zero-based index of this workbook view, pointing 
+    # Zero-based index of this workbook view, pointing
     # to a workbookView element in the bookViews collection.
     # @see type
-    # @return [Integer] 
+    # @return [Integer]
     # default 0
     attr_reader :workbook_view_id
 
     # Zoom Scale
-    # Window zoom magnification for current view 
+    # Window zoom magnification for current view
     # representing percent values. This attribute
-    # is restricted to values ranging from 10 to 400. 
+    # is restricted to values ranging from 10 to 400.
     # Horizontal & Vertical scale together.
-    # Current view can be Normal, Page Layout, or 
+    # Current view can be Normal, Page Layout, or
     # Page Break Preview.
     # @see type
-    # @return [Integer] 
+    # @return [Integer]
     # default 100
     attr_reader :zoom_scale
 
 
     # Zoom Scale Normal View
-    # Zoom magnification to use when in normal view, 
-    # representing percent values. This attribute is 
-    # restricted to values ranging from 10 to 400. 
+    # Zoom magnification to use when in normal view,
+    # representing percent values. This attribute is
+    # restricted to values ranging from 10 to 400.
     # Horizontal & Vertical scale together.
-    # Applies for worksheets only; zero implies the 
+    # Applies for worksheets only; zero implies the
     # automatic setting.
     # @see type
-    # @return [Integer] 
+    # @return [Integer]
     # default 0
     attr_reader :zoom_scale_normal
 
 
     # Zoom Scale Page Layout View
-    # Zoom magnification to use when in page layout 
-    # view, representing percent values. This attribute 
-    # is restricted to values ranging from 10 to 400. 
+    # Zoom magnification to use when in page layout
+    # view, representing percent values. This attribute
+    # is restricted to values ranging from 10 to 400.
     # Horizontal & Vertical scale together.
-    # Applies for worksheets only; zero implies 
+    # Applies for worksheets only; zero implies
     # the automatic setting.
     # @see type
-    # @return [Integer] 
+    # @return [Integer]
     # default 0
     attr_reader :zoom_scale_page_layout_view
 
 
     # Zoom Scale Page Break Preview
-    # Zoom magnification to use when in page break 
-    # preview, representing percent values. This 
-    # attribute is restricted to values ranging 
+    # Zoom magnification to use when in page break
+    # preview, representing percent values. This
+    # attribute is restricted to values ranging
     # from 10 to 400. Horizontal & Vertical scale
     # together.
-    # Applies for worksheet only; zero implies 
+    # Applies for worksheet only; zero implies
     # the automatic setting.
     # @see type
-    # @return [Integer] 
+    # @return [Integer]
     # default 0
     attr_reader :zoom_scale_sheet_layout_view
 
@@ -172,7 +172,7 @@ module Axlsx
     # @see top_left_cell
     def top_left_cell=(v)
       cell = (v.class == Axlsx::Cell ? v.r_abs : v)
-      Axlsx::validate_string(cell)  
+      Axlsx::validate_string(cell)
       @top_left_cell = cell
     end
 
@@ -198,16 +198,16 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<sheetViews>'
-      str << '<sheetView '
+      str << '<sheetViews>'\
+             '<sheetView '
       serialized_attributes str
       str << '>'
       @pane.to_xml_string(str) if @pane
       @selections.each do |key, selection|
         selection.to_xml_string(str)
       end
-      str << '</sheetView>'
-      str << '</sheetViews>'
+      str << '</sheetView>'\
+             '</sheetViews>'
     end
   end
 end

--- a/lib/axlsx/workbook/worksheet/sheet_view.rb
+++ b/lib/axlsx/workbook/worksheet/sheet_view.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # View options for a worksheet.
   #
@@ -197,7 +198,7 @@ module Axlsx
     # Serializes the data validation
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<sheetViews>'\
              '<sheetView '
       serialized_attributes str

--- a/lib/axlsx/workbook/worksheet/table.rb
+++ b/lib/axlsx/workbook/worksheet/table.rb
@@ -64,7 +64,7 @@ module Axlsx
       end
     end
 
-    # TableStyleInfo for the table. 
+    # TableStyleInfo for the table.
     # initialization can be fed via the :style_info option
     def table_style_info
       @table_style_info ||= TableStyleInfo.new
@@ -74,13 +74,13 @@ module Axlsx
     # @param [String] str
     # @return [String]
     def to_xml_string(str = '')
-      str << '<?xml version="1.0" encoding="UTF-8"?>'
-      str << ('<table xmlns="' << XML_NS << '" id="' << (index+1).to_s << '" name="' << @name << '" displayName="' << @name.gsub(/\s/,'_') << '" ')
-      str << ('ref="' << @ref << '" totalsRowShown="0">')
-      str << ('<autoFilter ref="' << @ref << '"/>')
-      str << ('<tableColumns count="' << header_cells.length.to_s << '">')
+      str << '<?xml version="1.0" encoding="UTF-8"?>'\
+             "<table xmlns=\"#{XML_NS}\" id=\"#{index + 1}\" name=\"#{@name}\" displayName=\"#{@name.gsub(/\s/,'_')}\" "\
+             "ref=\"#{@ref}\" totalsRowShown=\"0\">"\
+             "<autoFilter ref=\"#{@ref}\"/>"\
+             "<tableColumns count=\"#{header_cells.length}\">"
       header_cells.each_with_index do |cell,index|
-        str << ('<tableColumn id ="' << (index+1).to_s << '" name="' << cell.value << '"/>')
+        str << "<tableColumn id =\"#{index + 1}\" name=\"#{cell.value}\"/>"
       end
       str << '</tableColumns>'
       table_style_info.to_xml_string(str)

--- a/lib/axlsx/workbook/worksheet/table.rb
+++ b/lib/axlsx/workbook/worksheet/table.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
   # Table
   # @note Worksheet#add_table is the recommended way to create tables for your worksheets.
@@ -73,7 +74,7 @@ module Axlsx
     # Serializes the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       str << '<?xml version="1.0" encoding="UTF-8"?>'\
              "<table xmlns=\"#{XML_NS}\" id=\"#{index + 1}\" name=\"#{@name}\" displayName=\"#{@name.gsub(/\s/,'_')}\" "\
              "ref=\"#{@ref}\" totalsRowShown=\"0\">"\

--- a/lib/axlsx/workbook/worksheet/table_style_info.rb
+++ b/lib/axlsx/workbook/worksheet/table_style_info.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # The table style info class manages style attributes for defined tables in
@@ -42,7 +43,7 @@ module Axlsx
 
     # seralizes this object to an xml string
     # @param [String] str the string to contact this objects serialization to.
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       serialized_tag('tableStyleInfo', str)
     end
   end

--- a/lib/axlsx/workbook/worksheet/tables.rb
+++ b/lib/axlsx/workbook/worksheet/tables.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # A simple, self serializing class for storing tables
@@ -23,7 +24,7 @@ module Axlsx
     # renders the tables xml
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = "")
+    def to_xml_string(str = String.new)
       return if empty?
       str << "<tableParts count='#{size}'>"
       each { |table| str << "<tablePart r:id='#{table.rId}'/>" }

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -553,8 +553,8 @@ module Axlsx
       add_autofilter_defined_name_to_workbook
       str << '<sheet '
       serialized_attributes str
-      str << ('name="' << name << '" ')
-      str << ('r:id="' << rId << '"></sheet>')
+      str << "name=\"#{name}\" "\
+             "r:id=\"#{rId}\"></sheet>"
     end
 
     # Serializes the worksheet object to an xml string

--- a/lib/axlsx/workbook/worksheet/worksheet.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 module Axlsx
 
   # The Worksheet class represents a worksheet in the workbook.
@@ -549,7 +550,7 @@ module Axlsx
     end
 
     # Returns a sheet node serialization for this sheet in the workbook.
-    def to_sheet_node_xml_string(str='')
+    def to_sheet_node_xml_string(str = String.new)
       add_autofilter_defined_name_to_workbook
       str << '<sheet '
       serialized_attributes str
@@ -560,7 +561,7 @@ module Axlsx
     # Serializes the worksheet object to an xml string
     # This intentionally does not use nokogiri for performance reasons
     # @return [String]
-    def to_xml_string str=''
+    def to_xml_string(str = String.new)
       add_autofilter_defined_name_to_workbook
       auto_filter.apply if auto_filter.range
       str << '<?xml version="1.0" encoding="UTF-8"?>'

--- a/lib/axlsx/workbook/worksheet/worksheet_comments.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet_comments.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # A wraper class for comments that defines its on worksheet
@@ -50,7 +51,7 @@ module Axlsx
     # Seraalize the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       return unless has_comments?
       str << "<legacyDrawing r:id='#{drawing_rId}' />"
     end

--- a/lib/axlsx/workbook/worksheet/worksheet_drawing.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet_drawing.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # This is a utility class for serialing the drawing node in a
@@ -50,7 +51,7 @@ module Axlsx
 
     # Serialize the drawing for the worksheet
     # @param [String] str
-    def to_xml_string(str = '')
+    def to_xml_string(str = String.new)
       return unless has_drawing?
       str << "<drawing r:id='#{relationship.Id}'/>"
     end

--- a/lib/axlsx/workbook/worksheet/worksheet_hyperlink.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet_hyperlink.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   # A worksheet hyperlink object. Note that this is not the same as a drawing hyperlink object.
@@ -57,7 +58,7 @@ module Axlsx
     # Seralize the object
     # @param [String] str
     # @return [String]
-    def to_xml_string(str='')
+    def to_xml_string(str = String.new)
       str << '<hyperlink '
       serialized_attributes str, location_or_id
       str << '/>'

--- a/lib/axlsx/workbook/worksheet/worksheet_hyperlinks.rb
+++ b/lib/axlsx/workbook/worksheet/worksheet_hyperlinks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Axlsx
 
   #A collection of hyperlink objects for a worksheet
@@ -28,7 +29,7 @@ module Axlsx
 
     # seralize the collection of hyperlinks
     # @return [String]
-    def to_xml_string(str='')
+    def to_xml_string(str = String.new)
       return if empty?
       str << '<hyperlinks>'
       each { |hyperlink| hyperlink.to_xml_string(str) }


### PR DESCRIPTION
Hi, this is tiny optimization without complete refactoring or something.

The main idea: decrease count of allocated objects (mostly strings) by some ruby tricks and freezing.

Modern ruby versions allow not only just prevent strings from mutation with `freeze`, but also allocate it only once:
```ruby
# ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-linux]
2.2.2 :001 > 'asdads332'.freeze.object_id
# => 18294380 
2.2.2 :002 > 'asdads332'.freeze.object_id
# => 18294380 
2.2.2 :003 > 'asdads332'.freeze.object_id
# => 18294380 
```

If we need to support old ruby versions -- I suggest to consider it in a separate request.

Some measurements here: https://gist.github.com/korun/1f22ee8505122f2f307fc83dee3b9974

---
Refs #276