### PR TITLE
use thread locals to cache relationship instances

### DIFF
--- a/lib/axlsx/rels/relationship.rb
+++ b/lib/axlsx/rels/relationship.rb
@@ -8,7 +8,7 @@ module Axlsx
       # Keeps track of all instances of this class.
       # @return [Array]
       def instances
-        @instances ||= []
+        Thread.current["#{name}.instances"] ||= []
       end
       
       # Clear cached instances.
@@ -21,7 +21,7 @@ module Axlsx
       # Also, calling this avoids memory leaks (cached instances lingering around 
       # forever). 
       def clear_cached_instances
-        @instances = []
+        Thread.current["#{name}.instances"] = []
       end
       
       # Generate and return a unique id (eg. `rId123`) Used for setting {#Id}. 
@@ -30,7 +30,7 @@ module Axlsx
       # {clear_cached_instances} will automatically reset the generated ids, too.
       # @return [String]
       def next_free_id
-        "rId#{@instances.size + 1}"
+        "rId#{instances.size + 1}"
       end
     end
 

--- a/test/rels/tc_relationship.rb
+++ b/test/rels/tc_relationship.rb
@@ -41,4 +41,85 @@ class TestRelationships < Test::Unit::TestCase
     doc = Nokogiri::XML(r.to_xml_string)
     assert_equal(doc.xpath("//Relationship[@Target='http://example.com?foo=1&bar=2']").size, 1)
   end
+
+  def test_instances_cache_single_thread
+    d1 = doc
+    d2 = doc
+
+    package(d1)
+    package(d2)
+
+    worksheet(d1)
+    worksheet(d2)
+
+    xlsx1 = serialize(d1)
+    xlsx2 = serialize(d2)
+
+    assert_equal(read_workbook(xlsx1), read_workbook(xlsx2))
+  end
+
+  def test_instances_cache_thread_safety
+    d1 = doc
+    d2 = doc
+
+    q1 = Queue.new
+    q2 = Queue.new
+
+    t1 = thread(d1, q1)
+    t2 = thread(d2, q2)
+
+    q1.push(:package)
+    q2.push(:package)
+
+    q1.push(:worksheet)
+    q2.push(:worksheet)
+
+    q1.push(:serialize)
+    q2.push(:serialize)
+
+    q1.push(:done)
+    q2.push(:done)
+
+    t1.join
+    t2.join
+
+    assert_equal(read_workbook(t1[:serialize]), read_workbook(t2[:serialize]))
+  end
+
+  private
+
+  def doc
+    {}
+  end
+
+  def package(doc)
+    doc[:package] = Axlsx::Package.new
+  end
+
+  def worksheet(doc)
+    doc[:package].workbook.add_worksheet(name: 'My Sheet')
+  end
+
+  def serialize(doc)
+    doc[:package].to_stream.string
+  end
+
+  def thread(doc, queue)
+    Thread.new do
+      while (message = queue.pop) != :done
+        Thread.current[message] = send(message, doc)
+      end
+    end
+  end
+
+  def read_workbook(xlsx)
+    Zip::InputStream.open(StringIO.new(xlsx)) do |io|
+      res = nil
+      while (entry = io.get_next_entry)
+        res = io.read if entry.name == 'xl/workbook.xml'
+      end
+      res
+    end
+  end
+
 end


### PR DESCRIPTION
do not use class variables to make axlsx more thread safe

fixes #313 

this does not seem to break any test, but I have not testet a lot of cases manually...