### PR TITLE
Add option to protect against csv formula injection attacks

### DIFF
--- a/test/workbook/worksheet/tc_worksheet.rb
+++ b/test/workbook/worksheet/tc_worksheet.rb
@@ -589,4 +589,15 @@ class TestWorksheet < Test::Unit::TestCase
     assert_equal(doc.xpath('//xmlns:worksheet/xmlns:sheetPr/xmlns:outlinePr').size, 1)
     assert_equal(doc.xpath('//xmlns:worksheet/xmlns:sheetPr/xmlns:outlinePr[@summaryBelow=0][@summaryRight=1]').size, 1)
   end
+
+  def test_escape_formulas_option
+    # defends against malicious cell values that begin with '= + - or @' when escape_formulas is true
+    row = ['=HYPERLINK("http://www.example.com", "CSV Payload")', '+Foo', '-Bar', '@Baz']
+    @ws.add_row row, escape_formulas: true
+
+    assert_equal @ws.rows.first.cells.first.value, "'=HYPERLINK(\"http://www.example.com\", \"CSV Payload\")"
+    assert_equal @ws.rows.first.cells[1].value, "'+Foo"
+    assert_equal @ws.rows.first.cells[2].value, "'-Bar"
+    assert_equal @ws.rows.first.cells[3].value, "'@Baz"
+  end
 end


### PR DESCRIPTION
Added the option to pass in `formula_defense: true` into the `#add_row` method.

In John Legrand's words, from this issue https://github.com/randym/axlsx/issues/624
"""
It would be nice to be able to pass an option to block formula injection. We use this Gem to let clients export tables to excel sheets. This is an unsafe practice because a formula could be injected. There should be an ability to block these injections to OWASP standards. (prepending "'" to anything that starts with something possibly malicious. https://www.owasp.org/index.php/CSV_Injection
"""