### PR TITLE
return str on to_xml_string to fix Marker col/row settings

### DIFF
--- a/lib/axlsx/drawing/marker.rb
+++ b/lib/axlsx/drawing/marker.rb
@@ -60,6 +60,7 @@ module Axlsx
       [:col, :colOff, :row, :rowOff].each do |k|
         str << ('<xdr:' << k.to_s << '>' << self.send(k).to_s << '</xdr:' << k.to_s << '>')
       end
+      str
     end
     private
 


### PR DESCRIPTION
This fixes colOff and rowOff for embedded images