### PR TITLE
fix name_to_indices so that it accepts downcase

### DIFF
--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -80,7 +80,7 @@ module Axlsx
   def self.name_to_indices(name)
     raise ArgumentError, 'invalid cell name' unless name.size > 1
     # capitalization?!?
-    v = name[/[A-Z]+/].reverse.chars.reduce({:base=>1, :i=>0}) do  |val, c|
+    v = name[/[A-Z]+/i].reverse.chars.reduce({:base=>1, :i=>0}) do  |val, c|
       val[:i] += ((c.bytes.first - 64) * val[:base]); val[:base] *= 26; val
     end
     [v[:i]-1, ((name[/[1-9][0-9]*/]).to_i)-1]


### PR DESCRIPTION
Changing name_to_indices regex to ignore case 
### Occasion
I was adding some comments to an sheet through a job and i didn't pay attention to upcase. This took me some debugging to find why it threw errors so it could be a plus to ignore case on this method, or raise an descriptive error maybe.
