### PR TITLE
Set column width to the maximum allowed value

### DIFF
--- a/lib/axlsx/workbook/worksheet/col.rb
+++ b/lib/axlsx/workbook/worksheet/col.rb
@@ -4,6 +4,10 @@ module Axlsx
   # The Col class defines column attributes for columns in sheets.
   class Col
 
+    # Maximum column width limit in MS Excel is 255 characters
+    # https://support.microsoft.com/en-us/office/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3
+    MAX_WIDTH = 255
+
     include Axlsx::OptionsParser
     include Axlsx::SerializedAttributes
     # Create a new Col objects
@@ -111,10 +115,10 @@ module Axlsx
       # TODO!!!
       #Axlsx.validate_unsigned_numeric(v) unless v == nil
       @custom_width = @best_fit = v != nil
-      @width = v
+      @width = v.nil? ? v : [v, MAX_WIDTH].min
     end
 
-    # updates the width for this col based on the cells autowidth and 
+    # updates the width for this col based on the cells autowidth and
     # an optionally specified fixed width
     # @param [Cell] cell The cell to use in updating this col's width
     # @param [Integer] fixed_width If this is specified the width is set
@@ -127,8 +131,8 @@ module Axlsx
       elsif use_autowidth
        cell_width = cell.autowidth
        self.width = cell_width unless (width || 0) > (cell_width || 0)
-      end 
-    end 
+      end
+    end
 
     # Serialize this columns data to an xml string
     # @param [String] str

--- a/test/workbook/worksheet/tc_col.rb
+++ b/test/workbook/worksheet/tc_col.rb
@@ -7,7 +7,7 @@ class TestCol < Test::Unit::TestCase
   end
 
   def test_initialize
-    options = { :width => 12, :collapsed => true, :hidden => true, :outline_level => 1, :phonetic => true, :style => 1} 
+    options = { :width => 12, :collapsed => true, :hidden => true, :outline_level => 1, :phonetic => true, :style => 1}
 
     col = Axlsx::Col.new 0, 0, options
     options.each{ |key, value| assert_equal(col.send(key.to_sym), value) }
@@ -37,6 +37,21 @@ class TestCol < Test::Unit::TestCase
     @col.width = 3
     assert_raise(NoMethodError, 'customWidth is read only') { @col.customWidth = 3 }
     assert_equal(@col.customWidth, true, 'customWidth is true when width is set')
+  end
+
+  def test_widthUnderLimit
+    @col.width = 3
+    assert_equal(@col.width, 3, 'width is set to exact value')
+  end
+
+  def test_widthOverLimit
+    @col.width = 31337
+    assert_equal(@col.width, 255, 'width is set to maximum allowed value')
+  end
+
+  def test_widthSetToNil
+    @col.width = nil
+    assert_equal(@col.width, nil, 'width is set to unspecified value')
   end
 
   def test_hidden


### PR DESCRIPTION
Maximum column width limit in MS Excel is 255 characters https://support.microsoft.com/en-us/office/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3

If this value is exceeded, MS Excel gets stuck and doesn't allow column resizing.