### PR TITLE
Explicitly export 5-8 formats

### DIFF
--- a/lib/axlsx/stylesheet/styles.rb
+++ b/lib/axlsx/stylesheet/styles.rb
@@ -376,6 +376,10 @@ module Axlsx
       @numFmts = SimpleTypedList.new NumFmt, 'numFmts'
       @numFmts << NumFmt.new(:numFmtId => NUM_FMT_YYYYMMDD, :formatCode=> "yyyy/mm/dd")
       @numFmts << NumFmt.new(:numFmtId => NUM_FMT_YYYYMMDDHHMMSS, :formatCode=> "yyyy/mm/dd hh:mm:ss")
+      @numFmts << NumFmt.new(:numFmtId => NUM_FMT_CURRENCY_ROUNDED, :formatCode=> "&quot;$&quot;#,##0__);\(&quot;$&quot;#,##0\)")
+      @numFmts << NumFmt.new(:numFmtId => NUM_FMT_CURRENCY_ROUNDED_RED, :formatCode=> "&quot;$&quot;#,##0__);[Red]\(&quot;$&quot;#,##0\)")
+      @numFmts << NumFmt.new(:numFmtId => NUM_FMT_CURRENCY, :formatCode=> "&quot;$&quot;#,##0.00__);\(&quot;$&quot;#,##0.00\)")
+      @numFmts << NumFmt.new(:numFmtId => NUM_FMT_CURRENCY_RED, :formatCode=> "&quot;$&quot;#,##0.00__);[Red]\(&quot;$&quot;#,##0.00\)")
 
       @numFmts.lock
 

--- a/lib/axlsx/util/constants.rb
+++ b/lib/axlsx/util/constants.rb
@@ -259,6 +259,12 @@ module Axlsx
   # drawing validation schema
   DRAWING_XSD = (SCHEMA_BASE + "dml-spreadsheetDrawing.xsd").freeze
 
+  # Excel specific currency formats
+  NUM_FMT_CURRENCY_ROUNDED = 5
+  NUM_FMT_CURRENCY_ROUNDED_RED = 6
+  NUM_FMT_CURRENCY = 7
+  NUM_FMT_CURRENCY_RED = 8
+
   # number format id for pecentage formatting using the default formatting id.
   NUM_FMT_PERCENT = 9
 


### PR DESCRIPTION
Excel sheets that use formats 5-8 export the formatCodes for 5-8 because 5-8 are not standard values. Even though Excel can read a file without the formatCodes for cells using this `numFmtId` values other libraries may arise an exception when detecting format ids without an accompanying code.

This PR explicitly adds them to all files. I would have preferred to only include them if they were used but I punted since always including styles for 100 and 101 seem to have been included without issue.